### PR TITLE
fix: 物模型对象类型组件-表格添加禁用右键菜单(#35806)

### DIFF
--- a/components/Metadata/components/Object/Item.vue
+++ b/components/Metadata/components/Object/Item.vue
@@ -202,6 +202,7 @@ defineExpose({
       :validateRowKey="true"
       :columns="myColumns"
       :dataSource="dataSource"
+      :disableMenu="false"
       :pagination="false"
       :height="200"
     >


### PR DESCRIPTION
需要合并到2.10分支