### PR TITLE
feat(设备管理): 支持应用设备库解析模版

### DIFF
--- a/views/device/Instance/Detail/Parsing/ModbusMapping.vue
+++ b/views/device/Instance/Detail/Parsing/ModbusMapping.vue
@@ -10,6 +10,10 @@
             <a-radio-button value="TCP">TCP</a-radio-button>
             <a-radio-button value="RTU">RTU</a-radio-button>
           </a-radio-group>
+          <a-button size="small" class="mm-template-btn" :loading="applyingTemplate" @click="applyCurrentParserTemplate">
+            <template #icon><AppstoreOutlined /></template>
+            使用模版
+          </a-button>
           <span class="mm-link-type-hint">解析与编码：TCP 含 MBAP；RTU 含 CRC；PDU 为裸 PDU（与历史默认一致）</span>
         </div>
         <div ref="tableScrollEl" class="mm-table-scroll">
@@ -1242,9 +1246,11 @@ import {
   ExclamationCircleOutlined,
   ReloadOutlined,
   DownOutlined,
+  AppstoreOutlined,
 } from '@ant-design/icons-vue';
 import { useInstanceStore } from '../../../../../store/instance';
 import { deviceCode, saveDeviceCode, testCode, encodeTest } from '../../../../../api/instance';
+import { queryInstalledDeviceLibraryParserTemplate } from './deviceLibraryParserTemplate';
 
 const props = defineProps<{
   thingId?: string;
@@ -1438,6 +1444,7 @@ const modbusLinkType = ref<'PDU' | 'TCP' | 'RTU'>('PDU');
 const mappings = ref<ModbusSimpleMapping[]>([]);
 const loading = ref(false);
 const saving = ref(false);
+const applyingTemplate = ref(false);
 
 /** 属性列 AutoComplete 焦点行（用于收起态「名称 + id」叠层） */
 const focusedPropertyIndex = ref<number | null>(null);
@@ -2981,6 +2988,112 @@ const copyMapping = (index: number) => {
   const copy = { ...mappings.value[index] };
   mappings.value.splice(index + 1, 0, copy);
 };
+
+async function applyCurrentParserTemplate() {
+  const pId = props.productId || instanceStore.current?.productId;
+  if (!pId) {
+    message.warning('未找到产品信息');
+    return;
+  }
+
+  applyingTemplate.value = true;
+  try {
+    const template = await queryInstalledDeviceLibraryParserTemplate(pId);
+    if (!template) {
+      message.warning('未找到已安装的设备库模版');
+      return;
+    }
+    if (template.parserType && template.parserType.toLowerCase() !== 'modbus') {
+      message.warning('设备库模版不是 Modbus 数据解析');
+      return;
+    }
+
+    modbusLinkType.value = normalizeModbusLinkType(template.modbusLinkType);
+
+    const templateMappings = Array.isArray(template.mappings) ? template.mappings : [];
+    const rows = templateMappings.map(toModbusSimpleMapping).filter((row) => row.property && row.registerStr);
+    if (!rows.length) {
+      message.warning('设备库未配置点位映射');
+      return;
+    }
+
+    const knownKeys = new Set(mappings.value.map(mappingDuplicateKey).filter(Boolean));
+    const appendRows: ModbusSimpleMapping[] = [];
+    let skipped = 0;
+    rows.forEach((row) => {
+      autoFillLayout(row);
+      const key = mappingDuplicateKey(row);
+      if (key && knownKeys.has(key)) {
+        skipped += 1;
+        return;
+      }
+      if (key) knownKeys.add(key);
+      appendRows.push(row);
+    });
+
+    if (appendRows.length) {
+      mappings.value = [...mappings.value, ...appendRows];
+      message.success(
+        skipped
+          ? `已应用模版，新增 ${appendRows.length} 个点位，跳过 ${skipped} 个重复点位，请确认后保存配置`
+          : `已应用模版，新增 ${appendRows.length} 个点位，请确认后保存配置`,
+      );
+    } else {
+      message.info('模版点位均已存在，已同步链路类型，请确认后保存配置');
+    }
+  } catch (error: any) {
+    message.error(error?.message || '应用设备库模版失败');
+  } finally {
+    applyingTemplate.value = false;
+  }
+}
+
+function toModbusSimpleMapping(item: Record<string, unknown>): ModbusSimpleMapping {
+  const property = firstTemplateString(item.property);
+  const metaProp = metadataProperties.value.find((p) => p.id === property);
+  const bitLength = Number(item.bitLength);
+
+  return {
+    property,
+    propertyName: metaProp?.name || firstTemplateString(item.name, item.propertyName) || undefined,
+    propertyDataType: metaProp?.valueType?.type,
+    registerStr: firstTemplateString(item.register, item.registerStr),
+    codec: normalizeCodecId(firstTemplateString(item.codec)),
+    layout: firstTemplateString(item.layout),
+    scaleFactor: toFiniteNumberOr(item.scaleFactor, 1),
+    scale: Math.round(toFiniteNumberOr(item.scale, -1)),
+    bitLength: Number.isFinite(bitLength) && bitLength > 0 ? bitLength : undefined,
+    useMaskWrite: item.useMaskWrite === true,
+    readable: normalizeTemplateReadable(item.access, item.readable),
+    writable: normalizeTemplateWritable(item.access, item.writable),
+  };
+}
+
+function mappingDuplicateKey(item: ModbusSimpleMapping) {
+  const property = item.property.trim();
+  const register = item.registerStr.trim().toLowerCase();
+  return property && register ? `${property}::${register}` : '';
+}
+
+function normalizeTemplateReadable(access: unknown, readable: unknown) {
+  if (typeof readable === 'boolean') return readable;
+  if (access === 'write') return false;
+  return true;
+}
+
+function normalizeTemplateWritable(access: unknown, writable: unknown) {
+  if (typeof writable === 'boolean') return writable;
+  if (access === 'read') return false;
+  return true;
+}
+
+function firstTemplateString(...values: unknown[]) {
+  for (const value of values) {
+    const text = value == null ? '' : String(value).trim();
+    if (text) return text;
+  }
+  return '';
+}
 
 // ==================== API: Load/Save ====================
 function normalizeModbusLinkType(v: unknown): 'PDU' | 'TCP' | 'RTU' {

--- a/views/device/Instance/Detail/Parsing/deviceLibraryParserTemplate.ts
+++ b/views/device/Instance/Detail/Parsing/deviceLibraryParserTemplate.ts
@@ -1,0 +1,191 @@
+import { request } from '@jetlinks-web/core';
+
+export type DeviceLibraryParserTemplate = {
+  parserType?: string;
+  parserName?: string;
+  modbusLinkType?: string;
+  mappings?: Record<string, unknown>[];
+};
+
+type InstalledCapability = {
+  capabilityId?: string;
+  resourceId?: string;
+  resourcesId?: string;
+  id?: string;
+  dataId?: string;
+  productId?: string;
+  version?: string;
+  data?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+};
+
+type MarketplaceVersion = Record<string, unknown>;
+
+export async function queryInstalledDeviceLibraryParserTemplate(
+  productId: string,
+): Promise<DeviceLibraryParserTemplate | undefined> {
+  const installedRows = unwrapArray<InstalledCapability>(
+    await request.post('/marketplace/capabilities/device-template/installed', [productId]),
+  );
+  const matchedRows = installedRows.filter((row) => {
+    const installedProductId = firstString(
+      row.dataId,
+      row.productId,
+      row.data?.dataId,
+      row.data?.productId,
+      row.result?.dataId,
+      row.result?.productId,
+      row.extra?.dataId,
+      row.extra?.productId,
+    );
+    return !installedProductId || installedProductId === productId;
+  });
+
+  for (const row of matchedRows.length ? matchedRows : installedRows) {
+    const capabilityIds = uniqueStrings(row.capabilityId, row.resourceId, row.resourcesId, row.id);
+    const installedVersion = firstString(row.version);
+
+    for (const capabilityId of capabilityIds) {
+      const template = await queryCapabilityParserTemplate(capabilityId, installedVersion);
+      if (template) return template;
+    }
+  }
+
+  return undefined;
+}
+
+async function queryCapabilityParserTemplate(capabilityId: string, installedVersion?: string) {
+  const versions: string[] = [];
+  if (installedVersion) versions.push(installedVersion);
+
+  const published = latestPublishedVersion(
+    unwrapArray<MarketplaceVersion>(
+      await request.get(`/marketplace/capabilities/${encodeURIComponent(capabilityId)}/versions`).catch(() => []),
+    ),
+  );
+  const publishedVersion = firstString(published?.version);
+  if (publishedVersion) versions.push(publishedVersion);
+
+  for (const version of uniqueStrings(...versions)) {
+    const pkg = await request
+      .get(`/marketplace/capabilities/${encodeURIComponent(capabilityId)}/versions/${encodeURIComponent(version)}/package`)
+      .catch(() => undefined);
+    const template = extractParserTemplate(pkg);
+    if (template) return template;
+  }
+
+  return undefined;
+}
+
+function extractParserTemplate(payload: unknown): DeviceLibraryParserTemplate | undefined {
+  const source = unwrapResult(payload);
+  const candidates = collectTemplateCandidates(source);
+
+  for (const candidate of candidates) {
+    const template = readParserTemplate(candidate);
+    if (template) return template;
+  }
+
+  return undefined;
+}
+
+function collectTemplateCandidates(source: unknown) {
+  const root = parseJsonObject(source);
+  if (!root) return [];
+
+  const candidates: unknown[] = [root, root.capabilityPackage, root.package, root.resource];
+  const resources = Array.isArray(root.resources) ? root.resources : [];
+  candidates.push(
+    ...resources.filter((item) => isRecord(item) && item.type === 'device-template'),
+    ...resources,
+  );
+  return candidates;
+}
+
+function readParserTemplate(source: unknown): DeviceLibraryParserTemplate | undefined {
+  const node = parseJsonObject(source);
+  if (!node) return undefined;
+
+  const metadata = parseJsonObject(node.metadata);
+  const directTemplate = parseJsonObject(node.template);
+  const metadataTemplate = parseJsonObject(metadata?.template);
+  const template = directTemplate ?? metadataTemplate;
+  const dataParser = parseJsonObject(template?.dataParser ?? node.dataParser);
+  if (!dataParser) return undefined;
+
+  const mappings = Array.isArray(dataParser.mappings)
+    ? dataParser.mappings.filter(isRecord)
+    : undefined;
+
+  return {
+    parserType: firstString(dataParser.parserType),
+    parserName: firstString(dataParser.parserName),
+    modbusLinkType: firstString(dataParser.modbusLinkType),
+    mappings,
+  };
+}
+
+function latestPublishedVersion(versions: MarketplaceVersion[]) {
+  const sorted = [...versions].sort((left, right) => {
+    const timeGap = toVersionTime(right) - toVersionTime(left);
+    if (timeGap !== 0) return timeGap;
+    return firstString(right.version).localeCompare(firstString(left.version));
+  });
+
+  return sorted.find((item) => {
+    const state = firstString(item.state, item.status, item.releaseState, item.publishState).toLowerCase();
+    return !state || ['enabled', 'published', 'released', 'release', 'current'].includes(state);
+  }) ?? sorted[0];
+}
+
+function toVersionTime(version: MarketplaceVersion) {
+  const time = Number(version.releaseTime ?? version.createTime ?? version.updateTime);
+  return Number.isFinite(time) ? time : 0;
+}
+
+function unwrapArray<T>(payload: unknown): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (!isRecord(payload)) return [];
+  const result = 'result' in payload ? payload.result : 'data' in payload ? payload.data : payload;
+  if (Array.isArray(result)) return result as T[];
+  if (isRecord(result)) {
+    if (Array.isArray(result.data)) return result.data as T[];
+    if (Array.isArray(result.records)) return result.records as T[];
+  }
+  return [];
+}
+
+function unwrapResult(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+  if ('result' in payload) return payload.result;
+  if ('data' in payload) return payload.data;
+  return payload;
+}
+
+function parseJsonObject(value: unknown): Record<string, any> | undefined {
+  if (isRecord(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function firstString(...values: unknown[]) {
+  for (const value of values) {
+    const text = value == null ? '' : String(value).trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function uniqueStrings(...values: unknown[]) {
+  return [...new Set(values.map((item) => firstString(item)).filter(Boolean))];
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}


### PR DESCRIPTION
## 目的

- 新增设备详情 Modbus 数据解析页的“使用模版”能力。
- 通过当前产品 ID 查询已安装设备库，读取设备库数据解析模板，减少手工补点位映射的重复操作。

## 核心变动

- 设备管理 UI：在设备详情 Modbus 解析页接入“使用模版”按钮，应用模板时同步 `modbusLinkType` 到当前草稿。
- 设备管理 UI：新增 `deviceLibraryParserTemplate.ts`，封装已安装设备库查询、版本选择、能力包解析和 `metadata.template.dataParser` 提取。
- 设备管理 UI：模板点位按 `property + registerStr` 跳过重复项，只追加到当前页面草稿，不触发保存接口。

## 设计与测试目标

- 设计稿：`docs/plans/marketplace-data-parser-resource.md`
- 用户确认：已确认
- 测试目标：覆盖设备详情使用设备库模板读取点位、同步链路类型、跳过重复点位、不自动保存的核心路径；后端 package 运行时接口由配套 marketplace PR 提供。
- 注释 / 公共契约：不适用；本 PR 未新增公共 SPI 或后端公共契约。
- 数据权限：不适用；本 PR 未新增数据权限查询或资产权限动作。
- 数据库兼容与性能：不适用；本 PR 未涉及 SQL。
- 链路追踪：不适用；本 PR 为前端交互与请求封装。
- MBean 运维可观测性：不适用；本 PR 未涉及常驻内存任务或后台队列。

## 测试结果

- 命令：`PATH=/Users/hukaiyu/.nvm/versions/node/v22.18.0/bin:$PATH pnpm -C ui -F jetlinks-web-core build -- --module-name device-manager-ui`
- 新增/更新测试：无前端单测；通过模块构建覆盖 TS/Vue 编译与打包路径。
- 单元测试：不适用；当前模块未针对该页面建立单元测试入口。
- 集成测试：不适用；未直接触发数据库、消息、事件、协议或启动装配集成测试。
- 压力测试：不适用；未涉及 SQL 或批量写入性能路径。
- 覆盖率：无前端覆盖率报告；以 `device-manager-ui` 模块构建通过作为替代验证。

## 文档同步情况

- 已同步：`docs/plans/marketplace-data-parser-resource.md` 已在根工作区更新为本次方案说明，随聚合仓库文档交付。
- 未同步：无
- 说明：README 未发生长期总览变化，未新增独立任务流水文档。

## 风险与说明

- 影响范围：设备详情 Modbus 数据解析页；模板应用仅修改当前页面草稿。
- 注释 / 公共契约：不涉及公共 SPI；新增 helper 只封装页面侧请求与数据解析。
- 链路追踪 / 可观测性：不适用。
- MBean / 运维可观测性：不适用。
- 未覆盖场景：未在真实浏览器里重新点选设备库模板；依赖配套后端 PR 暴露运行时 package 接口。
- 已知限制：用户仍需点击“保存配置”才会持久化解析配置。
