### PR TITLE
feat(设备管理): 展示插件网关设备ID映射

### DIFF
--- a/views/device/Instance/Detail/Info/index.vue
+++ b/views/device/Instance/Detail/Info/index.vue
@@ -26,31 +26,7 @@
                 <div style="flex: 1">
                     <j-ellipsis> {{ instanceStore.current?.id }} </j-ellipsis>
                 </div>
-                <div
-                    v-if="
-                        instanceStore.current?.accessProvider ===
-                        'plugin_gateway'
-                    "
-                >
-                    <a-tooltip>
-                        <template #title>
-                            <p>
-                                {{ $t('Info.index.208636-3') }}
-                            </p>
-                            {{ $t('Info.index.208636-4') }}
-                        </template>
-                        <a
-                            v-if="!inklingDeviceId"
-                            type="link"
-                            @click="giveAnInkling"
-                        >
-                            {{ $t('Info.index.208636-5') }}
-                        </a>
-                        <a v-else type="link" @click="inkingVisible = true">
-                            {{ $t('Info.index.208636-6') }}
-                        </a>
-                    </a-tooltip>
-                </div>
+                <DeviceIdMapping @saved="handleConfigSaved" />
             </div>
         </a-descriptions-item>
         <a-descriptions-item :label="$t('Info.index.208636-7')">
@@ -122,14 +98,6 @@
         @close="visible = false"
         @save="saveBtn"
     />
-    <InkingModal
-        v-if="inkingVisible"
-        :id="inklingDeviceId"
-        :accessId="instanceStore.current.accessId"
-        :pluginId="channelId"
-        @cancel="inkingVisible = false"
-        @submit="saveInkling"
-    />
 </template>
 
 <script lang="ts" setup>
@@ -139,18 +107,13 @@ import Config from './components/Config/index.vue';
 import Principal from './components/Principal/index.vue';
 import Tags from './components/Tags/index.vue';
 import Relation from './components/Relation/index.vue';
-import InkingModal from './components/InklingModal';
+import DeviceIdMapping from '../components/DeviceIdMapping.vue';
 import dayjs from 'dayjs';
-import { detail as queryPluginAccessDetail } from '../../../../../api/link/accessConfig';
-import { getPluginData } from '../../../../../api/link/plugin';
 import {useI18n} from "vue-i18n";
 
 const { t: $t } = useI18n();
 const visible = ref<boolean>(false);
-const inkingVisible = ref<boolean>(false);
 const instanceStore = useInstanceStore();
-const inklingDeviceId = ref();
-const channelId = ref();
 const principalRef = ref();
 
 const saveBtn = () => {
@@ -182,69 +145,12 @@ const handleConfigSaved = () => {
     }
 };
 
-const saveInkling = (id: string) => {
-    if (instanceStore.current?.id) {
-        const refreshPromise = instanceStore.refresh(instanceStore.current?.id);
-        if (refreshPromise && typeof refreshPromise.then === 'function') {
-            refreshPromise.then(() => {
-                // 刷新接入身份信息
-                if (principalRef.value?.refresh) {
-                    principalRef.value.refresh();
-                }
-            });
-        } else {
-            // 如果不是 Promise，直接调用刷新
-            setTimeout(() => {
-                if (principalRef.value?.refresh) {
-                    principalRef.value.refresh();
-                }
-            }, 100);
-        }
-    }
-    channelId.value = id;
-    queryInkling();
-    inkingVisible.value = false;
-};
-
-const giveAnInkling = () => {
-    inkingVisible.value = true;
-};
-
-const queryInkling = () => {
-    if (instanceStore.current?.accessProvider === 'plugin_gateway') {
-        queryPluginAccessDetail(instanceStore.current?.accessId).then(
-            async (res) => {
-                if (res.success) {
-                    channelId.value = res.result.channelId;
-                    const pluginRes = await getPluginData(
-                        'device',
-                        instanceStore.current?.accessId,
-                        instanceStore.current?.id,
-                    );
-                    if (pluginRes.success) {
-                        inklingDeviceId.value = pluginRes.result?.externalId;
-                    }
-                }
-            },
-        );
-    }
-};
-
 onMounted(() => {
     // 设备编辑标签后，返回实力信息页面，标签栏没有更新
     if (instanceStore?.current?.id) {
         instanceStore.refresh(instanceStore.current.id);
     }
 });
-watch(
-    () => instanceStore.current?.id,
-    () => {
-        if (instanceStore.current?.id) {
-            queryInkling();
-        }
-    },
-    { immediate: true },
-);
 </script>
 
 <style lang="less" scoped>

--- a/views/device/Instance/Detail/components/DeviceIdMapping.vue
+++ b/views/device/Instance/Detail/components/DeviceIdMapping.vue
@@ -1,0 +1,123 @@
+<template>
+  <div
+    v-if="isPluginGateway"
+    class="device-id-mapping"
+  >
+    <a-tooltip>
+      <template #title>
+        <p>
+          {{ $t('Info.index.208636-3') }}
+        </p>
+        {{ $t('Info.index.208636-4') }}
+      </template>
+      <a
+        v-if="!inklingDeviceId"
+        type="link"
+        @click="openInklingModal"
+      >
+        {{ $t('Info.index.208636-5') }}
+      </a>
+      <a
+        v-else
+        type="link"
+        @click="openInklingModal"
+      >
+        {{ $t('Info.index.208636-6') }}
+      </a>
+    </a-tooltip>
+    <InkingModal
+      v-if="inkingVisible"
+      :id="inklingDeviceId"
+      :accessId="instanceStore.current.accessId"
+      :pluginId="channelId"
+      @cancel="inkingVisible = false"
+      @submit="saveInkling"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useInstanceStore } from '../../../../../store/instance'
+import { detail as queryPluginAccessDetail } from '../../../../../api/link/accessConfig'
+import { getPluginData } from '../../../../../api/link/plugin'
+import InkingModal from '../Info/components/InklingModal'
+import { useI18n } from 'vue-i18n'
+
+type Emit = {
+  (e: 'saved'): void
+}
+
+const emit = defineEmits<Emit>()
+const { t: $t } = useI18n()
+const instanceStore = useInstanceStore()
+const inkingVisible = ref(false)
+const inklingDeviceId = ref<string>()
+const channelId = ref<string>()
+
+const isPluginGateway = computed(() => instanceStore.current?.accessProvider === 'plugin_gateway')
+
+const refreshInstance = async () => {
+  if (!instanceStore.current?.id) return
+  const refreshPromise = instanceStore.refresh(instanceStore.current.id)
+  if (refreshPromise && typeof refreshPromise.then === 'function') {
+    await refreshPromise
+  }
+  // 映射保存会影响实例详情；Info 页还需要同步刷新接入身份信息。
+  emit('saved')
+}
+
+const saveInkling = async () => {
+  inkingVisible.value = false
+  await refreshInstance()
+  await queryInkling()
+}
+
+const openInklingModal = async () => {
+  if (!channelId.value) {
+    await queryInkling()
+  }
+  inkingVisible.value = true
+}
+
+const queryInkling = async () => {
+  if (!isPluginGateway.value || !instanceStore.current?.accessId || !instanceStore.current?.id) {
+    inklingDeviceId.value = undefined
+    channelId.value = undefined
+    return
+  }
+
+  const res = await queryPluginAccessDetail(instanceStore.current.accessId)
+  if (!res.success) return
+
+  channelId.value = res.result?.channelId
+  const pluginRes = await getPluginData(
+    'device',
+    instanceStore.current.accessId,
+    instanceStore.current.id
+  )
+  if (pluginRes.success) {
+    inklingDeviceId.value = pluginRes.result?.externalId
+  }
+}
+
+watch(
+  () => [
+    instanceStore.current?.id,
+    instanceStore.current?.accessId,
+    instanceStore.current?.accessProvider
+  ],
+  () => {
+    void queryInkling()
+  },
+  { immediate: true }
+)
+</script>
+
+<style lang="less" scoped>
+.device-id-mapping {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+}
+</style>

--- a/views/device/Instance/Detail/index.vue
+++ b/views/device/Instance/Detail/index.vue
@@ -146,6 +146,7 @@
                 {{ instanceStore.current?.id }}
               </span>
             </a-tooltip>
+	          <DeviceIdMapping class="device-detail-meta__mapping" />
             <span
               class="device-detail-meta__sep"
               aria-hidden="true"
@@ -322,6 +323,7 @@
 import TagsSave from './Info/components/Tags/Save.vue'
 import PhotoSave from './PhotoSave.vue'
 import DeviceDetailFishboneSkeleton from './DeviceDetailFishboneSkeleton.vue'
+import DeviceIdMapping from './components/DeviceIdMapping.vue'
 import { useInstanceStore } from '../../../../store/instance'
 import { _deploy, _disconnect, modifyByDeviceId } from '../../../../api/instance'
 import { getBase64ByImg, onlyMessage } from '@jetlinks-web/utils'


### PR DESCRIPTION
## 目的

- 在设备详情标题区的设备 ID 右侧展示插件网关设备 ID 映射状态。
- 复用实例信息页已有映射入口，并将映射查询、弹窗打开和保存刷新逻辑收敛为局部组件。

## 核心变动

- 设备详情：在标题区设备 ID 后增加 `DeviceIdMapping`，仅插件网关设备展示“未映射 / 已映射”入口。
- 实例信息：替换原内联映射模板和脚本状态，改用同一个 `DeviceIdMapping` 组件。
- 组件抽离：新增 `DeviceIdMapping.vue`，内部负责查询插件通道、读取映射关系、打开 `InklingModal`，保存后刷新实例并通知 Info 页刷新接入身份信息。

## 设计与测试目标

- 设计稿：不适用，本次为既有详情页局部展示增强和组件抽离。
- 用户确认：已确认，用户要求在详情标题 ID 右侧增加与实例信息页一致的映射信息并建议抽组件。
- 测试目标：覆盖插件网关条件展示、已有/未有映射入口复用、保存后实例刷新链路的类型正确性；未新增自动化 UI 用例。
- 注释 / 公共契约：适用；已在组件中补充保存后刷新事件边界注释。
- 数据权限：不适用，未调整后端接口、权限或数据查询范围。
- 数据库兼容与性能：不适用，纯前端展示改动。
- 链路追踪：不适用，未涉及后端链路。
- MBean 运维可观测性：不适用，未涉及常驻任务、缓存、队列或后台执行器。

## 测试结果

- 命令：`npx vue-tsc --noEmit`
- 新增/更新测试：0 个；本次为前端局部展示抽离，仓库当前无对应组件单测脚手架。
- 类型检查：0 errors，0 failed，命令退出码 0。
- 集成测试：不适用，未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配。
- 压力测试：不适用，纯前端局部展示改动。
- 覆盖率：未生成覆盖率；当前验证以 `vue-tsc` 类型检查和 staged diff 核对作为替代证据。

## 文档同步情况

- 已同步：无。
- 未同步：无，本次不改变长期功能说明、接口契约或模块总览。
- 说明：README 不涉及长期总览变化，测试证据放在 PR 描述中，未新增独立任务流水文档。

## 风险与说明

- 影响范围：设备详情页标题区、实例信息页设备 ID 行、插件网关设备 ID 映射弹窗入口。
- 注释 / 公共契约：已补组件保存后刷新事件边界注释；不涉及公共 API 或 SPI。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未进行浏览器 UI 冒烟，需评审或联调时在插件网关设备详情页确认“未映射 / 已映射”入口展示和弹窗保存。
- 已知限制：工作区存在其它未提交改动，本 PR 仅提交设备 ID 映射相关 3 个文件。
