### PR TITLE
feat（仪表盘）：补充设备管理组件缩略图

### DIFF
--- a/visDashboard/Base/CustomChartsCard/customChartsCard.svg
+++ b/visDashboard/Base/CustomChartsCard/customChartsCard.svg
@@ -1,0 +1,28 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="chartCardPrimary" x1="29" y1="48" x2="94" y2="12" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+    <linearGradient id="chartCardArea" x1="61" y1="13" x2="61" y2="51" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#0D6DFF" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <path d="M30 15H96M30 27H96M30 39H96M30 51H96" stroke="white" stroke-opacity="0.12" stroke-dasharray="2 2"/>
+  <path d="M31 46L42 38L52 41L64 27L75 32L86 18L94 22V51H31V46Z" fill="url(#chartCardArea)"/>
+  <path d="M31 46L42 38L52 41L64 27L75 32L86 18L94 22" stroke="url(#chartCardPrimary)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="#0D6DFF" stroke="#BEE5FB" stroke-width="1">
+    <circle cx="42" cy="38" r="2.3"/>
+    <circle cx="64" cy="27" r="2.3"/>
+    <circle cx="86" cy="18" r="2.3"/>
+  </g>
+  <circle cx="16" cy="21" r="10" fill="#0D6DFF" fill-opacity="0.12" stroke="#BEE5FB" stroke-opacity="0.5"/>
+  <path d="M10 24L14 20L18 22L23 15" stroke="url(#chartCardPrimary)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="7" y="38" width="18" height="3.5" rx="1.75" fill="white" fill-opacity="0.42"/>
+  <rect x="7" y="46" width="13" height="5" rx="2.5" fill="url(#chartCardPrimary)"/>
+  <path d="M6 57H96" stroke="white" stroke-opacity="0.2"/>
+  <circle cx="10" cy="62" r="2.5" fill="#3CD495"/>
+  <rect x="16" y="60" width="24" height="4" rx="2" fill="white" fill-opacity="0.28"/>
+  <rect x="78" y="59" width="18" height="6" rx="3" fill="#0D6DFF" fill-opacity="0.32"/>
+</svg>

--- a/visDashboard/Base/CustomImageCard/customImageCard.svg
+++ b/visDashboard/Base/CustomImageCard/customImageCard.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="customImageCardPrimary" x1="8" y1="10" x2="91" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="57" y="8" width="35" height="34" rx="4" fill="#0D6DFF" fill-opacity="0.12" stroke="#BEE5FB" stroke-opacity="0.55" stroke-width="1.5"/>
+  <circle cx="82" cy="17" r="4" fill="#0EECE4" fill-opacity="0.8"/>
+  <path d="M61 37L69 28L75 33L82 24L89 37H61Z" fill="url(#customImageCardPrimary)" fill-opacity="0.78"/>
+  <rect x="8" y="11" width="27" height="4" rx="2" fill="white" fill-opacity="0.38"/>
+  <path d="M9 35H15V23H20V35H26V18H31V35H38V27H43V35" stroke="url(#customImageCardPrimary)" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M7 48H93" stroke="white" stroke-opacity="0.2" stroke-width="1"/>
+  <circle cx="11" cy="57" r="3" fill="#3CD495"/>
+  <rect x="17" y="55" width="23" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+  <circle cx="61" cy="57" r="3" fill="#FF5B5B"/>
+  <rect x="67" y="55" width="25" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+</svg>

--- a/visDashboard/Chart/HistoryLineChart/historyLineChart.svg
+++ b/visDashboard/Chart/HistoryLineChart/historyLineChart.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="historyLinePrimary" x1="12" y1="49" x2="91" y2="13" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <path d="M10 13V53H94" stroke="#BEE5FB" stroke-opacity="0.55" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M11 23H94M11 33H94M11 43H94" stroke="white" stroke-opacity="0.12" stroke-dasharray="2 3"/>
+  <path d="M13 44C22 44 23 34 32 35C41 36 42 22 53 24C64 26 66 16 76 20C84 23 87 13 94 15" stroke="url(#historyLinePrimary)" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13 48C22 45 24 50 33 46C42 42 45 43 54 38C63 33 69 39 77 32C85 25 89 30 94 25" stroke="#BEE5FB" stroke-opacity="0.75" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <g fill="#0EECE4" stroke="#BEE5FB" stroke-width="1">
+    <circle cx="32" cy="35" r="2.5"/>
+    <circle cx="53" cy="24" r="2.5"/>
+    <circle cx="76" cy="20" r="2.5"/>
+  </g>
+  <path d="M23 53V57M43 53V57M63 53V57M83 53V57" stroke="white" stroke-opacity="0.45" stroke-width="1.2"/>
+  <circle cx="15" cy="59" r="3" stroke="#0D6DFF" stroke-width="1.5"/>
+  <path d="M15 57V59L17 60" stroke="#0EECE4" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/visDashboard/Chart/RealtimeLineChart/realtimeLineChart.svg
+++ b/visDashboard/Chart/RealtimeLineChart/realtimeLineChart.svg
@@ -1,0 +1,19 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="realtimeLinePrimary" x1="9" y1="48" x2="94" y2="14" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+    <linearGradient id="realtimeLineArea" x1="51" y1="21" x2="51" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#0D6DFF" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <path d="M8 17V54H95" stroke="#BEE5FB" stroke-opacity="0.5" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M9 29H95M9 41H95" stroke="white" stroke-opacity="0.12" stroke-dasharray="2 3"/>
+  <path d="M9 47C16 45 21 48 28 42C35 36 39 39 46 34C53 29 56 34 63 27C70 20 76 25 82 19C87 14 91 18 95 14V54H9V47Z" fill="url(#realtimeLineArea)"/>
+  <path d="M9 47C16 45 21 48 28 42C35 36 39 39 46 34C53 29 56 34 63 27C70 20 76 25 82 19C87 14 91 18 95 14" stroke="url(#realtimeLinePrimary)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="95" cy="14" r="3" fill="#0EECE4" stroke="#BEE5FB" stroke-width="1"/>
+  <circle cx="16" cy="12" r="3" fill="#3CD495"/>
+  <path d="M22 12H27L30 7L34 17L38 10L42 12H48" stroke="#0EECE4" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/visDashboard/Control/Enumeration/enumeration.svg
+++ b/visDashboard/Control/Enumeration/enumeration.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="enumerationPrimary" x1="10" y1="22" x2="89" y2="46" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="20" y="9" width="31" height="4" rx="2" fill="white" fill-opacity="0.38"/>
+  <rect x="8" y="22" width="84" height="25" rx="4" stroke="#BEE5FB" stroke-opacity="0.65" stroke-width="1.5"/>
+  <path d="M36 22V47M64 22V47" stroke="#BEE5FB" stroke-opacity="0.45" stroke-width="1.2"/>
+  <rect x="9.5" y="23.5" width="25" height="22" rx="2.5" fill="url(#enumerationPrimary)"/>
+  <circle cx="22" cy="34.5" r="4" fill="white" fill-opacity="0.9"/>
+  <rect x="43" y="32" width="14" height="5" rx="2.5" fill="white" fill-opacity="0.3"/>
+  <rect x="71" y="32" width="14" height="5" rx="2.5" fill="white" fill-opacity="0.3"/>
+  <path d="M31 55H69" stroke="#0D6DFF" stroke-opacity="0.7" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="31" cy="55" r="2.5" fill="#0EECE4"/>
+</svg>

--- a/visDashboard/Control/SwitchList/switchList.svg
+++ b/visDashboard/Control/SwitchList/switchList.svg
@@ -1,0 +1,22 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="switchListPrimary" x1="8" y1="14" x2="91" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <path d="M7 23H93M7 43H93" stroke="white" stroke-opacity="0.18"/>
+  <g stroke="#BEE5FB" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M15 8C10 8 8 12 8 15C8 18 10 19 11 21H19C20 19 22 18 22 15C22 11 19 8 15 8Z" fill="#0D6DFF" fill-opacity="0.18"/>
+    <path d="M12 25L15 28L19 24M12 35L15 32L19 36M11 51H19M13 55H17"/>
+  </g>
+  <rect x="28" y="12" width="29" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+  <rect x="28" y="31" width="22" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+  <rect x="28" y="50" width="27" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+  <rect x="68" y="9" width="25" height="12" rx="6" fill="url(#switchListPrimary)"/>
+  <circle cx="87" cy="15" r="4.5" fill="white"/>
+  <rect x="68" y="29" width="25" height="12" rx="6" fill="white" fill-opacity="0.2" stroke="#BEE5FB" stroke-opacity="0.45"/>
+  <circle cx="74" cy="35" r="4.5" fill="white" fill-opacity="0.65"/>
+  <rect x="68" y="48" width="25" height="12" rx="6" fill="url(#switchListPrimary)"/>
+  <circle cx="87" cy="54" r="4.5" fill="white"/>
+</svg>

--- a/visDashboard/Control/SwitchOne/switchOne.svg
+++ b/visDashboard/Control/SwitchOne/switchOne.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="switchOnePrimary" x1="27" y1="18" x2="74" y2="45" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="9" r="3" fill="#3CD495"/>
+  <path d="M43 9H32" stroke="white" stroke-opacity="0.32" stroke-width="3" stroke-linecap="round"/>
+  <path d="M57 9H68" stroke="white" stroke-opacity="0.32" stroke-width="3" stroke-linecap="round"/>
+  <rect x="20" y="19" width="60" height="28" rx="14" fill="url(#switchOnePrimary)"/>
+  <circle cx="66" cy="33" r="10" fill="white"/>
+  <path d="M31 33H43" stroke="white" stroke-opacity="0.8" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="37" cy="33" r="6" stroke="white" stroke-opacity="0.42" stroke-width="1.5"/>
+  <rect x="35" y="55" width="30" height="5" rx="2.5" fill="#BEE5FB" fill-opacity="0.45"/>
+</svg>

--- a/visDashboard/Control/SwitchTwo/switchTwo.svg
+++ b/visDashboard/Control/SwitchTwo/switchTwo.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="switchTwoPrimary" x1="27" y1="12" x2="73" y2="51" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="31" r="22" fill="#0D6DFF" fill-opacity="0.1" stroke="#BEE5FB" stroke-opacity="0.35" stroke-width="1.5"/>
+  <path d="M50 15V31" stroke="url(#switchTwoPrimary)" stroke-width="4" stroke-linecap="round"/>
+  <path d="M38 21C33 25 31 30 32 36C34 45 41 51 50 51C59 51 67 45 68 36C69 30 67 25 62 21" stroke="url(#switchTwoPrimary)" stroke-width="3.2" stroke-linecap="round"/>
+  <circle cx="50" cy="31" r="17" stroke="white" stroke-opacity="0.12" stroke-width="1" stroke-dasharray="2 3"/>
+  <circle cx="77" cy="15" r="3" fill="#3CD495"/>
+  <path d="M76 22C82 26 85 32 84 39" stroke="#0EECE4" stroke-opacity="0.7" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="36" y="58" width="28" height="4" rx="2" fill="white" fill-opacity="0.35"/>
+</svg>

--- a/visDashboard/DeviceManagement/DeviceCountCard/deviceCountCard.svg
+++ b/visDashboard/DeviceManagement/DeviceCountCard/deviceCountCard.svg
@@ -1,0 +1,19 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="deviceCountAccent" x1="55" y1="11" x2="88" y2="43" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4"/>
+      <stop offset="1" stop-color="#0D6DFF"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="12" width="28" height="5" rx="2.5" fill="#BEE5FB" fill-opacity="0.8"/>
+  <rect x="8" y="23" width="36" height="10" rx="3" fill="#0D6DFF" fill-opacity="0.22"/>
+  <rect x="8" y="23" width="23" height="10" rx="3" fill="#0D6DFF"/>
+  <path d="M60 15H83C86.3137 15 89 17.6863 89 21V40H54V21C54 17.6863 56.6863 15 60 15Z" fill="#0D6DFF" fill-opacity="0.12" stroke="url(#deviceCountAccent)" stroke-width="1.7"/>
+  <path d="M61 23H82M61 29H82M61 35H75" stroke="#BEE5FB" stroke-width="1.6" stroke-linecap="round"/>
+  <circle cx="83" cy="35" r="2" fill="#0EECE4"/>
+  <path d="M7 48H93" stroke="#BEE5FB" stroke-opacity="0.6"/>
+  <circle cx="11" cy="57" r="3" fill="#3CD495"/>
+  <rect x="17" y="54.5" width="21" height="5" rx="2.5" fill="#BEE5FB"/>
+  <circle cx="65" cy="57" r="3" fill="#FF4D4F"/>
+  <rect x="71" y="54.5" width="21" height="5" rx="2.5" fill="#BEE5FB"/>
+</svg>

--- a/visDashboard/DeviceManagement/DeviceMapCard/deviceMapCard.svg
+++ b/visDashboard/DeviceManagement/DeviceMapCard/deviceMapCard.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="deviceMapRoute" x1="11" y1="52" x2="89" y2="15" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <path d="M7 15L34 7L65 15L93 7V51L65 59L34 51L7 59V15Z" fill="#0D6DFF" fill-opacity="0.08" stroke="#BEE5FB" stroke-width="1.4" stroke-linejoin="round"/>
+  <path d="M34 7V51M65 15V59" stroke="#BEE5FB" stroke-width="1.2"/>
+  <path d="M12 49C22 38 28 45 39 33C47 24 54 37 64 29C75 20 80 24 89 15" stroke="url(#deviceMapRoute)" stroke-width="2" stroke-linecap="round" stroke-dasharray="3 3"/>
+  <path d="M20 19C15.5817 19 12 22.5817 12 27C12 33 20 39 20 39C20 39 28 33 28 27C28 22.5817 24.4183 19 20 19Z" fill="#0D6DFF" stroke="#BEE5FB" stroke-width="1.3"/>
+  <circle cx="20" cy="27" r="2.5" fill="#0EECE4"/>
+  <path d="M73 32C69.6863 32 67 34.6863 67 38C67 42.5 73 47 73 47C73 47 79 42.5 79 38C79 34.6863 76.3137 32 73 32Z" fill="#0EECE4" stroke="#0D6DFF" stroke-width="1.3"/>
+  <circle cx="73" cy="38" r="2" fill="#0D6DFF"/>
+  <circle cx="85" cy="23" r="7" fill="#0D6DFF" fill-opacity="0.2" stroke="#0D6DFF" stroke-width="1.4"/>
+  <circle cx="85" cy="23" r="2.5" fill="#0EECE4"/>
+</svg>

--- a/visDashboard/DeviceManagement/DeviceMessage/deviceMessage.svg
+++ b/visDashboard/DeviceManagement/DeviceMessage/deviceMessage.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="messageLine" x1="8" y1="48" x2="92" y2="14" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+    <linearGradient id="messageArea" x1="50" y1="18" x2="50" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4" stop-opacity="0.34"/>
+      <stop offset="1" stop-color="#0D6DFF" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <path d="M9 16H91M9 29H91M9 42H91M9 55H91" stroke="#BEE5FB" stroke-opacity="0.65" stroke-dasharray="2 3"/>
+  <path d="M9 48L20 43L30 46L41 32L52 37L63 26L73 30L83 17L91 21V55H9V48Z" fill="url(#messageArea)"/>
+  <path d="M9 48L20 43L30 46L41 32L52 37L63 26L73 30L83 17L91 21" stroke="url(#messageLine)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="41" cy="32" r="2.4" fill="#0D6DFF" stroke="#BEE5FB"/>
+  <circle cx="63" cy="26" r="2.4" fill="#0EECE4" stroke="#0D6DFF"/>
+  <path d="M67 8H91C93.2091 8 95 9.79086 95 12V20C95 22.2091 93.2091 24 91 24H84L79 28V24H76" fill="#0D6DFF" fill-opacity="0.16" stroke="#0D6DFF" stroke-width="1.4" stroke-linejoin="round"/>
+  <circle cx="84" cy="16" r="2" fill="#0EECE4"/>
+  <circle cx="90" cy="16" r="2" fill="#BEE5FB"/>
+</svg>

--- a/visDashboard/DeviceManagement/MessageVolumeCard/messageVolumeCard.svg
+++ b/visDashboard/DeviceManagement/MessageVolumeCard/messageVolumeCard.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="volumeTrend" x1="42" y1="44" x2="91" y2="18" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+    <linearGradient id="volumeFill" x1="68" y1="19" x2="68" y2="48" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4" stop-opacity="0.3"/>
+      <stop offset="1" stop-color="#0D6DFF" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="11" width="24" height="5" rx="2.5" fill="#BEE5FB"/>
+  <rect x="8" y="22" width="30" height="11" rx="3" fill="#0D6DFF"/>
+  <path d="M44 42L51 36L58 39L66 27L74 31L83 18L92 23V48H44V42Z" fill="url(#volumeFill)"/>
+  <path d="M44 42L51 36L58 39L66 27L74 31L83 18L92 23" stroke="url(#volumeTrend)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7 49H93" stroke="#BEE5FB"/>
+  <path d="M12 55H32C34.2091 55 36 56.7909 36 59V61H12C9.79086 61 8 59.2091 8 57C8 55.8954 8.89543 55 10 55H12Z" fill="#0D6DFF" fill-opacity="0.18" stroke="#0D6DFF" stroke-width="1.2"/>
+  <path d="M17 55V50L22 55" stroke="#0EECE4" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="73" y="54" width="20" height="7" rx="3.5" fill="#0EECE4" fill-opacity="0.3"/>
+</svg>

--- a/visDashboard/DeviceManagement/OnlineCountCard/onlineCountCard.svg
+++ b/visDashboard/DeviceManagement/OnlineCountCard/onlineCountCard.svg
@@ -1,0 +1,19 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="onlineTrend" x1="42" y1="43" x2="93" y2="15" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="11" width="23" height="5" rx="2.5" fill="#BEE5FB"/>
+  <rect x="8" y="22" width="29" height="11" rx="3" fill="#0D6DFF"/>
+  <path d="M43 43L51 37L59 40L68 25L77 29L86 17L93 21" stroke="url(#onlineTrend)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M43 48H93" stroke="#BEE5FB"/>
+  <circle cx="51" cy="37" r="2.5" fill="#0D6DFF" stroke="#BEE5FB"/>
+  <circle cx="68" cy="25" r="2.5" fill="#0EECE4" stroke="#0D6DFF"/>
+  <circle cx="86" cy="17" r="2.5" fill="#0EECE4" stroke="#0D6DFF"/>
+  <path d="M8 56H92" stroke="#BEE5FB" stroke-opacity="0.8"/>
+  <circle cx="13" cy="56" r="4" fill="#3CD495"/>
+  <path d="M11 56L12.5 57.5L15.5 54.5" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="21" y="53.5" width="25" height="5" rx="2.5" fill="#0D6DFF" fill-opacity="0.2"/>
+</svg>

--- a/visDashboard/DeviceManagement/OnlineRateCard/onlineRateCard.svg
+++ b/visDashboard/DeviceManagement/OnlineRateCard/onlineRateCard.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="onlineRateRing" x1="53" y1="10" x2="89" y2="49" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4"/>
+      <stop offset="1" stop-color="#0D6DFF"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="12" width="24" height="5" rx="2.5" fill="#BEE5FB"/>
+  <rect x="8" y="23" width="31" height="10" rx="3" fill="#0D6DFF"/>
+  <circle cx="70" cy="30" r="19" stroke="#BEE5FB" stroke-width="7" stroke-opacity="0.55"/>
+  <path d="M70 11C80.4934 11 89 19.5066 89 30C89 40.4934 80.4934 49 70 49C62.1472 49 55.4054 44.2394 52.5084 37.4443" stroke="url(#onlineRateRing)" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="70" cy="30" r="4" fill="#0EECE4" fill-opacity="0.35" stroke="#0D6DFF" stroke-width="1.5"/>
+  <path d="M7 56H93" stroke="#BEE5FB"/>
+  <circle cx="12" cy="56" r="3" fill="#3CD495"/>
+  <rect x="18" y="53.5" width="22" height="5" rx="2.5" fill="#0D6DFF" fill-opacity="0.2"/>
+</svg>

--- a/visDashboard/DeviceManagement/ProductCountCard/productCountCard.svg
+++ b/visDashboard/DeviceManagement/ProductCountCard/productCountCard.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="productBox" x1="55" y1="15" x2="87" y2="43" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4"/>
+      <stop offset="1" stop-color="#0D6DFF"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="12" width="27" height="5" rx="2.5" fill="#BEE5FB"/>
+  <rect x="8" y="23" width="34" height="10" rx="3" fill="#0D6DFF"/>
+  <path d="M71 10L89 19V39L71 48L53 39V19L71 10Z" fill="#0D6DFF" fill-opacity="0.1" stroke="url(#productBox)" stroke-width="1.7" stroke-linejoin="round"/>
+  <path d="M53 19L71 29L89 19M71 29V48" stroke="#BEE5FB" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M61 15L80 25V33" stroke="#0EECE4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7 51H93" stroke="#BEE5FB"/>
+  <circle cx="11" cy="59" r="3" fill="#3CD495"/>
+  <rect x="17" y="56.5" width="21" height="5" rx="2.5" fill="#BEE5FB"/>
+  <circle cx="65" cy="59" r="3" fill="#FF4D4F"/>
+  <rect x="71" y="56.5" width="21" height="5" rx="2.5" fill="#BEE5FB"/>
+</svg>

--- a/visDashboard/Information/NumericalInfoOne/numericalInfoOne.svg
+++ b/visDashboard/Information/NumericalInfoOne/numericalInfoOne.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <defs>
+    <linearGradient id="nio-value" x1="22" y1="20" x2="78" y2="48" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#34D6FF"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+  </defs>
+  <rect x="7" y="9" width="26" height="48" rx="5" fill="#EAF5FF" stroke="#B8D9F5"/>
+  <rect x="37" y="9" width="26" height="48" rx="5" fill="#F0F7FF" stroke="#C5DDF3"/>
+  <rect x="67" y="9" width="26" height="48" rx="5" fill="#EAF5FF" stroke="#B8D9F5"/>
+  <rect x="13" y="17" width="14" height="3" rx="1.5" fill="#90A9BE"/>
+  <rect x="43" y="17" width="14" height="3" rx="1.5" fill="#90A9BE"/>
+  <rect x="73" y="17" width="14" height="3" rx="1.5" fill="#90A9BE"/>
+  <rect x="13" y="28" width="15" height="9" rx="2.5" fill="url(#nio-value)"/>
+  <rect x="43" y="28" width="15" height="9" rx="2.5" fill="url(#nio-value)"/>
+  <rect x="73" y="28" width="15" height="9" rx="2.5" fill="url(#nio-value)"/>
+  <circle cx="16" cy="46" r="2" fill="#55C895"/>
+  <rect x="20" y="44.5" width="8" height="3" rx="1.5" fill="#B6CADB"/>
+  <circle cx="46" cy="46" r="2" fill="#F6B84B"/>
+  <rect x="50" y="44.5" width="8" height="3" rx="1.5" fill="#B6CADB"/>
+  <circle cx="76" cy="46" r="2" fill="#55C895"/>
+  <rect x="80" y="44.5" width="8" height="3" rx="1.5" fill="#B6CADB"/>
+</svg>

--- a/visDashboard/Information/SwitchSignalLight/switchSignalLight.svg
+++ b/visDashboard/Information/SwitchSignalLight/switchSignalLight.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <defs>
+    <linearGradient id="ssl-green" x1="18" y1="20" x2="36" y2="38" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8AE6B5"/>
+      <stop offset="1" stop-color="#28B978"/>
+    </linearGradient>
+    <linearGradient id="ssl-red" x1="42" y1="20" x2="60" y2="38" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF9D9D"/>
+      <stop offset="1" stop-color="#F05A67"/>
+    </linearGradient>
+    <linearGradient id="ssl-blue" x1="66" y1="20" x2="84" y2="38" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#75DDFF"/>
+      <stop offset="1" stop-color="#4389F5"/>
+    </linearGradient>
+  </defs>
+  <rect x="9" y="8" width="82" height="50" rx="7" fill="#F5F9FC" stroke="#D4E2ED"/>
+  <circle cx="27" cy="29" r="12" fill="#DDF7EA"/>
+  <circle cx="27" cy="29" r="8" fill="url(#ssl-green)"/>
+  <circle cx="51" cy="29" r="12" fill="#FDE7E8"/>
+  <circle cx="51" cy="29" r="8" fill="url(#ssl-red)"/>
+  <circle cx="75" cy="29" r="12" fill="#E1F1FF"/>
+  <circle cx="75" cy="29" r="8" fill="url(#ssl-blue)"/>
+  <rect x="19" y="46" width="16" height="3" rx="1.5" fill="#A9BDCC"/>
+  <rect x="43" y="46" width="16" height="3" rx="1.5" fill="#A9BDCC"/>
+  <rect x="67" y="46" width="16" height="3" rx="1.5" fill="#A9BDCC"/>
+</svg>

--- a/visDashboard/Information/SwitchStatusOne/switchStatusOne.svg
+++ b/visDashboard/Information/SwitchStatusOne/switchStatusOne.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <defs>
+    <linearGradient id="sso-active" x1="17" y1="17" x2="43" y2="45" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFD36A"/>
+      <stop offset="1" stop-color="#F59A23"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="9" width="39" height="48" rx="7" fill="#FFF7E8" stroke="#F5D59A"/>
+  <rect x="53" y="9" width="39" height="48" rx="7" fill="#F3F7FA" stroke="#D5E0E8"/>
+  <circle cx="27.5" cy="29" r="11" fill="#FFE9BA"/>
+  <path d="M27.5 20.5a7 7 0 0 0-4.1 12.67c.83.6 1.3 1.3 1.4 2.08h5.4c.1-.78.57-1.48 1.4-2.08A7 7 0 0 0 27.5 20.5Z" fill="url(#sso-active)"/>
+  <rect x="25" y="36.5" width="5" height="2" rx="1" fill="#E68B17"/>
+  <circle cx="72.5" cy="29" r="11" fill="#E4EBF0"/>
+  <path d="M72.5 20.5a7 7 0 0 0-4.1 12.67c.83.6 1.3 1.3 1.4 2.08h5.4c.1-.78.57-1.48 1.4-2.08a7 7 0 0 0-4.1-12.67Z" fill="#96A9B7"/>
+  <rect x="70" y="36.5" width="5" height="2" rx="1" fill="#7F93A2"/>
+  <rect x="18" y="47" width="19" height="3" rx="1.5" fill="#D5AB5F"/>
+  <rect x="63" y="47" width="19" height="3" rx="1.5" fill="#AFC0CC"/>
+</svg>

--- a/visDashboard/List/DeviceAlarmRecord/deviceAlarmRecord.svg
+++ b/visDashboard/List/DeviceAlarmRecord/deviceAlarmRecord.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <rect x="7" y="8" width="86" height="50" rx="6" fill="#F8FAFC" stroke="#D6E2EB"/>
+  <rect x="14" y="14" width="29" height="4" rx="2" fill="#71899D"/>
+  <rect x="70" y="14" width="15" height="4" rx="2" fill="#B7C8D5"/>
+  <path d="M7 23h86" stroke="#DCE6EE"/>
+  <path d="M7 35h86M7 47h86" stroke="#E3EBF1"/>
+  <path d="M15 31.5 19 25l4 6.5h-8Z" fill="#F05A67"/>
+  <circle cx="19" cy="41" r="3.5" fill="#F6B84B"/>
+  <circle cx="19" cy="53" r="3.5" fill="#55C895"/>
+  <rect x="28" y="27" width="24" height="3" rx="1.5" fill="#8CA1B2"/>
+  <rect x="28" y="39.5" width="19" height="3" rx="1.5" fill="#9AAEBD"/>
+  <rect x="28" y="51.5" width="27" height="3" rx="1.5" fill="#9AAEBD"/>
+  <rect x="59" y="27" width="14" height="3" rx="1.5" fill="#C1D0DB"/>
+  <rect x="59" y="39.5" width="18" height="3" rx="1.5" fill="#C1D0DB"/>
+  <rect x="59" y="51.5" width="12" height="3" rx="1.5" fill="#C1D0DB"/>
+  <rect x="79" y="26" width="7" height="5" rx="2.5" fill="#FAD9DD"/>
+  <rect x="79" y="38.5" width="7" height="5" rx="2.5" fill="#FDE9C4"/>
+  <rect x="79" y="50.5" width="7" height="5" rx="2.5" fill="#DDF4E9"/>
+</svg>

--- a/visDashboard/List/DeviceCard/deviceCard.svg
+++ b/visDashboard/List/DeviceCard/deviceCard.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <defs>
+    <linearGradient id="dc-panel" x1="9" y1="8" x2="89" y2="59" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FCFF"/>
+      <stop offset="1" stop-color="#EAF4FC"/>
+    </linearGradient>
+  </defs>
+  <rect x="7" y="8" width="41" height="23" rx="5" fill="url(#dc-panel)" stroke="#C8DEEF"/>
+  <rect x="52" y="8" width="41" height="23" rx="5" fill="url(#dc-panel)" stroke="#C8DEEF"/>
+  <rect x="7" y="35" width="41" height="23" rx="5" fill="url(#dc-panel)" stroke="#C8DEEF"/>
+  <rect x="52" y="35" width="41" height="23" rx="5" fill="url(#dc-panel)" stroke="#C8DEEF"/>
+  <rect x="13" y="14" width="10" height="10" rx="2.5" fill="#D9ECFA"/>
+  <path d="M16 17h4v4h-4zM15 18h-1M22 18h-1M18 16v-1M18 23v-1" stroke="#4389D9" stroke-linecap="round"/>
+  <rect x="58" y="14" width="10" height="10" rx="2.5" fill="#D9ECFA"/>
+  <path d="M61 17h4v4h-4zM60 18h-1M67 18h-1M63 16v-1M63 23v-1" stroke="#4389D9" stroke-linecap="round"/>
+  <rect x="13" y="41" width="10" height="10" rx="2.5" fill="#D9ECFA"/>
+  <path d="M16 44h4v4h-4zM15 45h-1M22 45h-1M18 43v-1M18 50v-1" stroke="#4389D9" stroke-linecap="round"/>
+  <rect x="58" y="41" width="10" height="10" rx="2.5" fill="#D9ECFA"/>
+  <path d="M61 44h4v4h-4zM60 45h-1M67 45h-1M63 43v-1M63 50v-1" stroke="#4389D9" stroke-linecap="round"/>
+  <rect x="27" y="14" width="13" height="3" rx="1.5" fill="#8199AC"/>
+  <rect x="72" y="14" width="13" height="3" rx="1.5" fill="#8199AC"/>
+  <rect x="27" y="41" width="13" height="3" rx="1.5" fill="#8199AC"/>
+  <rect x="72" y="41" width="13" height="3" rx="1.5" fill="#8199AC"/>
+  <circle cx="29" cy="23" r="2" fill="#55C895"/>
+  <circle cx="74" cy="23" r="2" fill="#F05A67"/>
+  <circle cx="29" cy="50" r="2" fill="#55C895"/>
+  <circle cx="74" cy="50" r="2" fill="#55C895"/>
+  <rect x="33" y="21.5" width="9" height="3" rx="1.5" fill="#BDD0DD"/>
+  <rect x="78" y="21.5" width="9" height="3" rx="1.5" fill="#BDD0DD"/>
+  <rect x="33" y="48.5" width="9" height="3" rx="1.5" fill="#BDD0DD"/>
+  <rect x="78" y="48.5" width="9" height="3" rx="1.5" fill="#BDD0DD"/>
+</svg>

--- a/visDashboard/List/DeviceList/deviceList.svg
+++ b/visDashboard/List/DeviceList/deviceList.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <rect x="7" y="8" width="86" height="50" rx="6" fill="#F9FBFD" stroke="#D6E2EB"/>
+  <rect x="7.5" y="21" width="85" height="11" fill="#EAF5FF"/>
+  <rect x="13" y="13" width="19" height="3" rx="1.5" fill="#8299AB"/>
+  <rect x="52" y="13" width="13" height="3" rx="1.5" fill="#9DAFBC"/>
+  <rect x="73" y="13" width="12" height="3" rx="1.5" fill="#9DAFBC"/>
+  <path d="M7 21h86M7 32h86M7 43h86" stroke="#DDE7EE"/>
+  <circle cx="15" cy="26.5" r="2.5" fill="#55C895"/>
+  <circle cx="15" cy="37.5" r="2.5" fill="#55C895"/>
+  <circle cx="15" cy="49" r="2.5" fill="#F05A67"/>
+  <rect x="21" y="25" width="23" height="3" rx="1.5" fill="#6F8A9E"/>
+  <rect x="21" y="36" width="19" height="3" rx="1.5" fill="#8CA1B2"/>
+  <rect x="21" y="47.5" width="25" height="3" rx="1.5" fill="#8CA1B2"/>
+  <rect x="52" y="25" width="13" height="3" rx="1.5" fill="#ADC0CE"/>
+  <rect x="52" y="36" width="16" height="3" rx="1.5" fill="#ADC0CE"/>
+  <rect x="52" y="47.5" width="11" height="3" rx="1.5" fill="#ADC0CE"/>
+  <rect x="74" y="24" width="12" height="5" rx="2.5" fill="#D8F2E5"/>
+  <rect x="74" y="35" width="12" height="5" rx="2.5" fill="#D8F2E5"/>
+  <rect x="74" y="46.5" width="12" height="5" rx="2.5" fill="#FAD9DD"/>
+</svg>

--- a/visDashboard/List/NumericalListOne/numericalListOne.svg
+++ b/visDashboard/List/NumericalListOne/numericalListOne.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="66" viewBox="0 0 100 66" fill="none">
+  <defs>
+    <linearGradient id="nlo-icon" x1="12" y1="14" x2="28" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#67D9F6"/>
+      <stop offset="1" stop-color="#4C7FF1"/>
+    </linearGradient>
+  </defs>
+  <rect x="7" y="8" width="86" height="50" rx="6" fill="#F7FAFD" stroke="#D7E3EC"/>
+  <path d="M12 25h76M12 41h76" stroke="#E0E9F0"/>
+  <circle cx="20" cy="17" r="6" fill="#DFEFFC"/>
+  <path d="m20 12 4.5 2.5v5L20 22l-4.5-2.5v-5L20 12Z" fill="url(#nlo-icon)"/>
+  <circle cx="20" cy="33" r="6" fill="#E7F4FF"/>
+  <path d="M17 36V31l3-2 3 2v5h-6Z" fill="url(#nlo-icon)"/>
+  <circle cx="20" cy="49" r="6" fill="#E5F2FF"/>
+  <path d="M16.5 49h7M20 45.5v7" stroke="url(#nlo-icon)" stroke-width="2" stroke-linecap="round"/>
+  <rect x="31" y="15" width="20" height="3" rx="1.5" fill="#8DA3B4"/>
+  <rect x="31" y="31.5" width="16" height="3" rx="1.5" fill="#8DA3B4"/>
+  <rect x="31" y="47.5" width="22" height="3" rx="1.5" fill="#8DA3B4"/>
+  <rect x="62" y="13" width="20" height="7" rx="2" fill="#CFE9FF"/>
+  <rect x="62" y="29" width="20" height="7" rx="2" fill="#D7EDFF"/>
+  <rect x="62" y="45" width="20" height="7" rx="2" fill="#CFE9FF"/>
+  <rect x="66" y="15" width="10" height="3" rx="1.5" fill="#4389E5"/>
+  <rect x="66" y="31" width="8" height="3" rx="1.5" fill="#4389E5"/>
+  <rect x="66" y="47" width="11" height="3" rx="1.5" fill="#4389E5"/>
+  <circle cx="79" cy="16.5" r="1.5" fill="#86B8E7"/>
+  <circle cx="79" cy="32.5" r="1.5" fill="#86B8E7"/>
+  <circle cx="79" cy="48.5" r="1.5" fill="#86B8E7"/>
+</svg>

--- a/visDashboard/Map/AMap/aMap.svg
+++ b/visDashboard/Map/AMap/aMap.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="amapPin" x1="49" y1="13" x2="66" y2="42" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4"/>
+      <stop offset="1" stop-color="#0D6DFF"/>
+    </linearGradient>
+  </defs>
+  <path d="M5 17L32 8L63 16L95 7V50L64 59L33 51L5 59V17Z" fill="#0D6DFF" fill-opacity="0.07" stroke="#BEE5FB" stroke-width="1.4" stroke-linejoin="round"/>
+  <path d="M32 8L33 51M63 16L64 59" stroke="#BEE5FB" stroke-width="1.2"/>
+  <path d="M8 32C18 24 25 33 34 25C44 16 53 24 61 31C71 40 83 32 93 39" stroke="#0EECE4" stroke-width="2" stroke-linecap="round"/>
+  <path d="M10 50C21 42 26 44 36 38C47 31 53 39 63 42C73 46 81 45 92 20" stroke="#0D6DFF" stroke-width="2" stroke-linecap="round"/>
+  <path d="M55 12C48.9249 12 44 16.9249 44 23C44 31 55 40 55 40C55 40 66 31 66 23C66 16.9249 61.0751 12 55 12Z" fill="url(#amapPin)" stroke="#BEE5FB" stroke-width="1.4"/>
+  <circle cx="55" cy="23" r="3.5" fill="#0D6DFF" stroke="#BEE5FB" stroke-width="1.2"/>
+  <circle cx="84" cy="16" r="7" fill="#0D6DFF" fill-opacity="0.12" stroke="#0D6DFF" stroke-width="1.3"/>
+  <path d="M84 11L86 16L84 21L82 16L84 11Z" fill="#0EECE4"/>
+</svg>

--- a/visDashboard/MetadataManagement/EventShowCard/eventShowCard.svg
+++ b/visDashboard/MetadataManagement/EventShowCard/eventShowCard.svg
@@ -1,0 +1,18 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="eventAccent" x1="12" y1="10" x2="87" y2="57" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="8" width="88" height="50" rx="5" stroke="#BEE5FB" stroke-width="1.5"/>
+  <path d="M6 20H94M26 20V58M73 20V58" stroke="#BEE5FB" stroke-width="1"/>
+  <rect x="11" y="13" width="30" height="3" rx="1.5" fill="#0D6DFF" fill-opacity="0.55"/>
+  <circle cx="16" cy="29" r="3" fill="#0D6DFF"/>
+  <circle cx="16" cy="39" r="3" fill="#0EECE4"/>
+  <circle cx="16" cy="49" r="3" fill="#0D6DFF" fill-opacity="0.4"/>
+  <path d="M32 29H66M32 39H62M32 49H67" stroke="#0D6DFF" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+  <path d="M78 29H88M78 39H88M78 49H88" stroke="#BEE5FB" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="84" cy="14" r="6" fill="url(#eventAccent)"/>
+  <path d="M82 14L84 16L87 12" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/visDashboard/MetadataManagement/IndividualCard/individualCard.svg
+++ b/visDashboard/MetadataManagement/IndividualCard/individualCard.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="individualAccent" x1="10" y1="12" x2="43" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="24" cy="31" r="17" fill="#0D6DFF" fill-opacity="0.1" stroke="#BEE5FB" stroke-width="1.5"/>
+  <path d="M20 17H28M22 17V25L15 39C14 41 15.5 44 18 44H30C32.5 44 34 41 33 39L26 25V17" stroke="url(#individualAccent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M18 37H30" stroke="#0EECE4" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="22" cy="34" r="1.5" fill="#0D6DFF"/>
+  <rect x="49" y="17" width="31" height="5" rx="2.5" fill="#BEE5FB"/>
+  <rect x="49" y="28" width="43" height="12" rx="3" fill="#0D6DFF" fill-opacity="0.22"/>
+  <rect x="53" y="31" width="26" height="6" rx="3" fill="url(#individualAccent)"/>
+  <rect x="49" y="47" width="20" height="4" rx="2" fill="#BEE5FB" fill-opacity="0.8"/>
+  <rect x="73" y="47" width="10" height="4" rx="2" fill="#0EECE4" fill-opacity="0.7"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertyBattery/propertyBattery.svg
+++ b/visDashboard/MetadataManagement/PropertyBattery/propertyBattery.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="batteryCharge" x1="22" y1="54" x2="55" y2="14" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="9" width="38" height="49" rx="7" stroke="#BEE5FB" stroke-width="2"/>
+  <rect x="29" y="5" width="12" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="21" y="44" width="28" height="9" rx="2" fill="#0D6DFF"/>
+  <rect x="21" y="32" width="28" height="9" rx="2" fill="#0D6DFF" fill-opacity="0.8"/>
+  <rect x="21" y="20" width="28" height="9" rx="2" fill="url(#batteryCharge)"/>
+  <rect x="21" y="12" width="28" height="5" rx="2" fill="#BEE5FB" fill-opacity="0.45"/>
+  <path d="M65 20H90M65 29H82" stroke="#BEE5FB" stroke-width="3" stroke-linecap="round"/>
+  <path d="M65 43H84" stroke="#0D6DFF" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="89" cy="43" r="3.5" fill="#0EECE4"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertyChart/propertyChart.svg
+++ b/visDashboard/MetadataManagement/PropertyChart/propertyChart.svg
@@ -1,0 +1,22 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="propertyLine" x1="40" y1="49" x2="94" y2="13" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+    <linearGradient id="propertyArea" x1="68" y1="18" x2="68" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4" stop-opacity="0.32"/>
+      <stop offset="1" stop-color="#0D6DFF" stop-opacity="0.04"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="10" width="25" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="6" y="25" width="26" height="10" rx="3" fill="#0D6DFF" fill-opacity="0.22"/>
+  <rect x="10" y="28" width="17" height="4" rx="2" fill="#0D6DFF"/>
+  <rect x="6" y="42" width="17" height="4" rx="2" fill="#BEE5FB" fill-opacity="0.75"/>
+  <path d="M36 8V57" stroke="#BEE5FB" stroke-width="1" stroke-dasharray="3 3"/>
+  <path d="M41 20H95M41 36H95M41 52H95" stroke="#BEE5FB" stroke-opacity="0.65" stroke-width="1" stroke-dasharray="2 3"/>
+  <path d="M42 48C49 48 51 38 58 40C65 42 67 29 74 31C81 33 84 17 94 15V53H42V48Z" fill="url(#propertyArea)"/>
+  <path d="M42 48C49 48 51 38 58 40C65 42 67 29 74 31C81 33 84 17 94 15" stroke="url(#propertyLine)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="74" cy="31" r="2.5" fill="#0D6DFF" stroke="#BEE5FB"/>
+  <circle cx="94" cy="15" r="2.5" fill="#0EECE4" stroke="#BEE5FB"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertyProgress/propertyProgress.svg
+++ b/visDashboard/MetadataManagement/PropertyProgress/propertyProgress.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="progressFill" x1="9" y1="40" x2="72" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="10" width="35" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="8" y="21" width="24" height="9" rx="3" fill="#0D6DFF" fill-opacity="0.2"/>
+  <rect x="12" y="24" width="16" height="3" rx="1.5" fill="#0D6DFF"/>
+  <rect x="8" y="37" width="84" height="8" rx="4" fill="#BEE5FB" fill-opacity="0.5"/>
+  <rect x="8" y="37" width="62" height="8" rx="4" fill="url(#progressFill)"/>
+  <circle cx="70" cy="41" r="6" fill="#0EECE4" stroke="#BEE5FB" stroke-width="1.5"/>
+  <path d="M8 54H18M82 54H92" stroke="#BEE5FB" stroke-width="3" stroke-linecap="round"/>
+  <path d="M49 49V55" stroke="#0D6DFF" stroke-opacity="0.45" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertyShowCard/propertyShowCard.svg
+++ b/visDashboard/MetadataManagement/PropertyShowCard/propertyShowCard.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="propertyCardsAccent" x1="13" y1="14" x2="87" y2="54" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="7" y="7" width="32" height="4" rx="2" fill="#0D6DFF" fill-opacity="0.65"/>
+  <rect x="7" y="17" width="40" height="40" rx="5" stroke="#BEE5FB" stroke-width="1.5"/>
+  <rect x="53" y="17" width="40" height="40" rx="5" stroke="#BEE5FB" stroke-width="1.5"/>
+  <rect x="13" y="23" width="17" height="3" rx="1.5" fill="#BEE5FB"/>
+  <circle cx="39" cy="25" r="2" fill="#0D6DFF"/>
+  <rect x="13" y="32" width="25" height="8" rx="3" fill="#0D6DFF" fill-opacity="0.18"/>
+  <rect x="17" y="34" width="17" height="4" rx="2" fill="url(#propertyCardsAccent)"/>
+  <rect x="13" y="47" width="20" height="3" rx="1.5" fill="#BEE5FB" fill-opacity="0.75"/>
+  <rect x="59" y="23" width="17" height="3" rx="1.5" fill="#BEE5FB"/>
+  <circle cx="85" cy="25" r="2" fill="#0EECE4"/>
+  <path d="M60 39L66 34L72 37L79 29L86 33" stroke="url(#propertyCardsAccent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="59" y="47" width="20" height="3" rx="1.5" fill="#BEE5FB" fill-opacity="0.75"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertySignal/propertySignal.svg
+++ b/visDashboard/MetadataManagement/PropertySignal/propertySignal.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="signalAccent" x1="10" y1="12" x2="58" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EECE4"/>
+      <stop offset="1" stop-color="#0D6DFF"/>
+    </linearGradient>
+  </defs>
+  <path d="M9 25C21 11 43 11 55 25" stroke="url(#signalAccent)" stroke-width="5" stroke-linecap="round"/>
+  <path d="M16 34C25 24 39 24 48 34" stroke="url(#signalAccent)" stroke-width="5" stroke-linecap="round"/>
+  <path d="M24 43C29 38 35 38 40 43" stroke="#0D6DFF" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="32" cy="52" r="5" fill="#0D6DFF"/>
+  <rect x="66" y="15" width="25" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="66" y="28" width="26" height="10" rx="3" fill="#0D6DFF" fill-opacity="0.2"/>
+  <rect x="70" y="31" width="17" height="4" rx="2" fill="#0D6DFF"/>
+  <rect x="66" y="46" width="14" height="4" rx="2" fill="#BEE5FB" fill-opacity="0.75"/>
+  <circle cx="87" cy="48" r="3" fill="#0EECE4"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertySlider/propertySlider.svg
+++ b/visDashboard/MetadataManagement/PropertySlider/propertySlider.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sliderFill" x1="8" y1="40" x2="64" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="10" width="30" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="8" y="21" width="21" height="9" rx="3" fill="#0D6DFF" fill-opacity="0.2"/>
+  <rect x="12" y="24" width="13" height="3" rx="1.5" fill="#0D6DFF"/>
+  <rect x="8" y="38" width="84" height="5" rx="2.5" fill="#BEE5FB" fill-opacity="0.55"/>
+  <rect x="8" y="38" width="56" height="5" rx="2.5" fill="url(#sliderFill)"/>
+  <circle cx="64" cy="40.5" r="8" fill="#0D6DFF" stroke="#BEE5FB" stroke-width="2"/>
+  <circle cx="64" cy="40.5" r="3" fill="#0EECE4"/>
+  <path d="M8 51V55M29 51V54M50 51V54M71 51V54M92 51V55" stroke="#BEE5FB" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/visDashboard/MetadataManagement/PropertySwitch/propertySwitch.svg
+++ b/visDashboard/MetadataManagement/PropertySwitch/propertySwitch.svg
@@ -1,0 +1,16 @@
+<svg width="100" height="66" viewBox="0 0 100 66" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="switchFill" x1="50" y1="24" x2="91" y2="46" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0D6DFF"/>
+      <stop offset="1" stop-color="#0EECE4"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="13" width="30" height="4" rx="2" fill="#BEE5FB"/>
+  <rect x="8" y="28" width="23" height="10" rx="3" fill="#0D6DFF" fill-opacity="0.2"/>
+  <rect x="12" y="31" width="15" height="4" rx="2" fill="#0D6DFF"/>
+  <rect x="48" y="21" width="45" height="26" rx="13" fill="url(#switchFill)"/>
+  <circle cx="80" cy="34" r="9" fill="white" stroke="#BEE5FB" stroke-width="1.5"/>
+  <path d="M55 34H62" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="18" cy="51" r="3" fill="#0EECE4"/>
+  <rect x="25" y="49" width="18" height="4" rx="2" fill="#BEE5FB" fill-opacity="0.8"/>
+</svg>


### PR DESCRIPTION
## 变更内容

- 为设备管理仪表盘组件补充 32 个原生 SVG 缩略图
- 覆盖基础、图表、控制、设备管理、信息、列表、地图和物模型管理分类
- 保持缩略图与对应组件目录同级，供组件列表直接加载

## 验证

- git diff --check origin/2.12...HEAD：通过
- xmllint：32 个 SVG 全部通过 XML 结构校验