### PR TITLE
feat(设备管理): 支持运行时设备国际化

### DIFF
--- a/api/instance.ts
+++ b/api/instance.ts
@@ -42,6 +42,12 @@ export const detail = (id: string, hiddenError?: any) => request.get<DeviceInsta
 export const query = (data?: Record<string, any>) => request.post('/device-instance/_query', data)
 
 /**
+ * 查询设备并返回所属产品的当前语言名称。
+ */
+export const queryWithProductI18n = (data?: Record<string, any>) =>
+  request.post('/device-instance/i18n/_query', data)
+
+/**
  * 不分页查询设备
  * @param data
  * @returns

--- a/components/I18n/I18nInputTrigger.vue
+++ b/components/I18n/I18nInputTrigger.vue
@@ -1,0 +1,37 @@
+<template>
+  <span
+    class="i18n-input-trigger-wrapper"
+    @mousedown="stopPropagation"
+    @click="configure"
+  >
+    <a-tooltip :title="$t('I18n.configure')">
+      <AIcon class="i18n-input-trigger" type="GlobalOutlined" />
+    </a-tooltip>
+  </span>
+</template>
+
+<script setup lang="ts">
+const emit = defineEmits<{
+  (e: 'configure'): void
+}>()
+
+function stopPropagation(event?: Event) {
+  event?.stopPropagation()
+}
+
+function configure(event?: Event) {
+  event?.stopPropagation()
+  emit('configure')
+}
+</script>
+
+<style scoped lang="less">
+.i18n-input-trigger-wrapper {
+  display: inline-flex;
+}
+
+.i18n-input-trigger {
+  color: var(--jet-theme-primary);
+  cursor: pointer;
+}
+</style>

--- a/components/I18n/I18nTextDialog.vue
+++ b/components/I18n/I18nTextDialog.vue
@@ -1,0 +1,104 @@
+<template>
+  <a-modal
+    :open="visible"
+    :title="title"
+    :width="600"
+    :mask-closable="false"
+    @cancel="handleCancel"
+    @ok="handleOk"
+  >
+    <a-form ref="formRef" :model="formData" :rules="rules" layout="vertical">
+      <a-form-item
+        v-for="language in languages"
+        :key="language.code"
+        :label="language.label"
+        :name="language.code"
+      >
+        <a-textarea
+          v-if="textarea"
+          v-model:value="formData[language.code]"
+          :rows="4"
+          :maxlength="maxLength"
+          :placeholder="$t('I18n.placeholder', { language: language.label })"
+          show-count
+        />
+        <a-input
+          v-else
+          v-model:value="formData[language.code]"
+          :maxlength="maxLength"
+          :placeholder="$t('I18n.placeholder', { language: language.label })"
+        />
+      </a-form-item>
+    </a-form>
+  </a-modal>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = withDefaults(defineProps<{
+  visible: boolean
+  title: string
+  data?: Record<string, string>
+  displayValue?: string
+  maxLength?: number
+  textarea?: boolean
+}>(), {
+  data: () => ({}),
+  maxLength: 200,
+  textarea: false,
+})
+
+const emit = defineEmits<{
+  (e: 'update:visible', visible: boolean): void
+  (e: 'confirm', data: Record<string, string>): void
+}>()
+
+const { t, locale } = useI18n()
+const formRef = ref()
+const formData = reactive<Record<string, string>>({})
+const languages = computed(() => [
+  { code: 'zh', label: t('I18n.chinese') },
+  { code: 'en', label: t('I18n.english') },
+])
+const currentLanguage = computed(() => String(locale.value || 'zh').replace('_', '-').split('-')[0])
+const rules = computed(() => ({
+  zh: [{ max: props.maxLength, message: t('I18n.maxLength', { max: props.maxLength }), trigger: 'blur' }],
+  en: [{ max: props.maxLength, message: t('I18n.maxLength', { max: props.maxLength }), trigger: 'blur' }],
+}))
+
+function initFormData() {
+  languages.value.forEach((language) => {
+    formData[language.code] = props.data?.[language.code] || ''
+  })
+  if (!formData[currentLanguage.value] && props.displayValue) {
+    formData[currentLanguage.value] = props.displayValue
+  }
+}
+
+watch(() => props.visible, (visible) => {
+  if (visible) {
+    initFormData()
+  }
+}, { immediate: true })
+
+function handleCancel() {
+  emit('update:visible', false)
+  formRef.value?.resetFields()
+}
+
+function handleOk() {
+  formRef.value?.validate().then(() => {
+    const result: Record<string, string> = {}
+    Object.entries(formData).forEach(([language, value]) => {
+      const text = value?.trim()
+      if (text) {
+        result[language] = text
+      }
+    })
+    emit('confirm', result)
+    emit('update:visible', false)
+  })
+}
+</script>

--- a/components/I18n/I18nTextField.vue
+++ b/components/I18n/I18nTextField.vue
@@ -1,0 +1,107 @@
+<template>
+  <div v-if="!textarea" class="i18n-input-field">
+    <a-input
+      v-bind="$attrs"
+      :value="value"
+      @update:value="emit('update:value', $event)"
+    />
+    <I18nInputTrigger class="i18n-input-field__trigger" @configure="visible = true" />
+  </div>
+  <div v-else class="i18n-textarea-field">
+    <a-textarea
+      v-bind="$attrs"
+      :value="value"
+      @update:value="emit('update:value', $event)"
+    />
+    <I18nInputTrigger class="i18n-textarea-field__trigger" @configure="visible = true" />
+  </div>
+  <a-form-item-rest>
+    <I18nTextDialog
+      v-if="visible"
+      :visible="visible"
+      :title="dialogTitle"
+      :data="fieldI18nMessages"
+      :display-value="value"
+      :max-length="i18nMaxLength"
+      :textarea="textarea"
+      @update:visible="visible = $event"
+      @confirm="saveI18nMessages"
+    />
+  </a-form-item-rest>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import I18nInputTrigger from './I18nInputTrigger.vue'
+import I18nTextDialog from './I18nTextDialog.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  value?: string
+  i18nMessages?: Record<string, Record<string, string>>
+  field: string
+  label: string
+  i18nMaxLength?: number
+  textarea?: boolean
+}>(), {
+  value: '',
+  i18nMessages: () => ({}),
+  i18nMaxLength: 200,
+  textarea: false,
+})
+
+const emit = defineEmits<{
+  (e: 'update:value', value: string): void
+  (e: 'update:i18nMessages', value: Record<string, Record<string, string>>): void
+}>()
+
+const { t } = useI18n()
+const visible = ref(false)
+const fieldI18nMessages = computed(() => props.i18nMessages?.[props.field] ?? {})
+const dialogTitle = computed(() => `${t('I18n.configure')} - ${props.label}`)
+
+function saveI18nMessages(messages: Record<string, string>) {
+  emit('update:i18nMessages', {
+    ...(props.i18nMessages ?? {}),
+    [props.field]: messages,
+  })
+}
+</script>
+
+<style scoped lang="less">
+.i18n-textarea-field {
+  position: relative;
+}
+
+.i18n-input-field {
+  position: relative;
+}
+
+.i18n-input-field__trigger {
+  position: absolute;
+  top: 50%;
+  right: var(--space-2);
+  z-index: 1;
+  transform: translateY(-50%);
+}
+
+.i18n-input-field :deep(.ant-input) {
+  padding-right: var(--space-8);
+}
+
+.i18n-input-field :deep(.ant-input-clear-icon) {
+  margin-right: var(--space-5);
+}
+
+.i18n-textarea-field__trigger {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+}
+
+.i18n-textarea-field :deep(.ant-input-textarea-show-count::after) {
+  padding-right: var(--space-5);
+}
+</style>

--- a/locales/lang/en.json
+++ b/locales/lang/en.json
@@ -4175,5 +4175,10 @@
     "DeviceDetail.edgeTools.mbean.scopes.threading": "JVM threading",
     "DeviceDetail.edgeTools.mbean.scopes.runtime": "JVM runtime",
     "DeviceDetail.edgeTools.mbean.scopes.os": "Operating system",
-    "DeviceDetail.edgeTools.mbean.scopes.gc": "JVM GC"
+    "DeviceDetail.edgeTools.mbean.scopes.gc": "JVM GC",
+    "I18n.configure": "Internationalization settings",
+    "I18n.chinese": "Chinese",
+    "I18n.english": "English",
+    "I18n.placeholder": "Enter {language}",
+    "I18n.maxLength": "Must not exceed {max} characters"
 }

--- a/locales/lang/zh.json
+++ b/locales/lang/zh.json
@@ -4176,5 +4176,10 @@
     "DeviceDetail.edgeTools.mbean.scopes.threading": "JVM 线程",
     "DeviceDetail.edgeTools.mbean.scopes.runtime": "JVM 运行时",
     "DeviceDetail.edgeTools.mbean.scopes.os": "操作系统",
-    "DeviceDetail.edgeTools.mbean.scopes.gc": "JVM GC"
+    "DeviceDetail.edgeTools.mbean.scopes.gc": "JVM GC",
+    "I18n.configure": "国际化配置",
+    "I18n.chinese": "中文",
+    "I18n.english": "English",
+    "I18n.placeholder": "请输入{language}",
+    "I18n.maxLength": "长度不能超过{max}个字符"
 }

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -1,0 +1,20 @@
+type I18nDisplayRecord = Record<string, unknown>
+
+const toI18nField = (field: string) => `i18n${field.charAt(0).toUpperCase()}${field.slice(1)}`
+
+/**
+ * 优先使用服务端根据请求语言解析的展示字段，兼容未迁移的历史数据。
+ */
+export const getI18nText = (source: I18nDisplayRecord | null | undefined, field: string): string => {
+  if (!source) {
+    return ''
+  }
+
+  const localized = source[toI18nField(field)]
+  if (typeof localized === 'string' && localized.trim()) {
+    return localized
+  }
+
+  const value = source[field]
+  return typeof value === 'string' ? value : ''
+}

--- a/views/device/Category/components/modifyModal/index.vue
+++ b/views/device/Category/components/modifyModal/index.vue
@@ -15,8 +15,12 @@
   >
     <a-form layout="vertical" ref="formRef" :rules="rules" :model="formModel">
       <a-form-item :label="$t('modifyModal.index.177674-2')" name="name">
-        <a-input
+        <I18nTextField
           v-model:value="formModel.name"
+          v-model:i18nMessages="formModel.i18nMessages"
+          field="name"
+          :label="$t('modifyModal.index.177674-2')"
+          :i18n-max-length="64"
           :placeholder="$t('modifyModal.index.177674-3')"
         />
       </a-form-item>
@@ -32,8 +36,12 @@
         />
       </a-form-item>
       <a-form-item :label="$t('modifyModal.index.177674-6')">
-        <a-textarea
+        <I18nTextField
           v-model:value="formModel.description"
+          v-model:i18nMessages="formModel.i18nMessages"
+          field="description"
+          :label="$t('modifyModal.index.177674-6')"
+          textarea
           show-count
           :maxlength="200"
           :placeholder="$t('modifyModal.index.177674-7')"
@@ -48,6 +56,7 @@ import { Form } from "ant-design-vue";
 import { queryTree, saveTree, updateTree } from "../../../../../api/category";
 import { onlyMessage } from "@jetlinks-web-core/utils/comm";
 import { useI18n } from "vue-i18n";
+import I18nTextField from "../../../../../components/I18n/I18nTextField.vue";
 
 const { t: $t } = useI18n();
 
@@ -76,6 +85,7 @@ interface formState {
   name: string;
   sortIndex: number;
   description: string;
+  i18nMessages?: Record<string, Record<string, string>>;
 }
 const listData = ref([]);
 const childArr = ref([]);
@@ -91,6 +101,7 @@ const formModel = ref<formState>({
   name: "",
   sortIndex: 1,
   description: "",
+  i18nMessages: {},
 });
 const rules = ref({
   name: [
@@ -190,6 +201,7 @@ const show = async (row: any) => {
               ? childArr.value[childArr.value.length - 1].sortIndex
               : childArr.value[childArr.value.length - 1].sortIndex + 1,
           description: "",
+          i18nMessages: {},
         };
         visible.value = true;
       }
@@ -204,6 +216,7 @@ const show = async (row: any) => {
               ? arr.value[arr.value.length - 1].sortIndex
               : arr.value[arr.value.length - 1].sortIndex + 1,
           description: "",
+          i18nMessages: {},
         };
       }
       visible.value = true;
@@ -217,6 +230,7 @@ const show = async (row: any) => {
           name: "",
           sortIndex: 1,
           description: "",
+          i18nMessages: {},
         };
         visible.value = true;
       }
@@ -228,6 +242,7 @@ const show = async (row: any) => {
       name: row.name,
       sortIndex: row.sortIndex,
       description: row.description,
+      i18nMessages: row.i18nMessages || {},
     };
     visible.value = true;
   }

--- a/views/device/Category/typings.d.ts
+++ b/views/device/Category/typings.d.ts
@@ -6,5 +6,7 @@ export type CategoryItem = {
   parentId: string;
   path: string;
   sortIndex: number;
+  description?: string;
+  i18nMessages?: Record<string, Record<string, string>>;
   children?: Category[];
 };

--- a/views/device/Instance/Detail/DeviceDocument/index.vue
+++ b/views/device/Instance/Detail/DeviceDocument/index.vue
@@ -29,14 +29,14 @@
         <template v-if="column.key === 'name'">
           <div class="device-document-name">
             <AIcon type="FileTextOutlined" />
-            <span>{{ record.name || fileName(record) }}</span>
+            <span>{{ getI18nText(record, 'name') || fileName(record) }}</span>
           </div>
         </template>
         <template v-else-if="column.key === 'documentType'">
           <a-tag>{{ documentTypeText(record.documentType) }}</a-tag>
         </template>
         <template v-else-if="column.key === 'fileId'">
-          <j-ellipsis>{{ record.fileId }}</j-ellipsis>
+          <j-ellipsis>{{ getI18nText(record, 'fileId') }}</j-ellipsis>
         </template>
         <template v-else-if="column.key === 'createTime'">
           {{ record.createTime ? dayjs(record.createTime).format('YYYY-MM-DD HH:mm:ss') : '-' }}
@@ -111,6 +111,7 @@ import {
   saveDeviceDocuments
 } from '../../../../../api/instance'
 import { useInstanceStore } from '../../../../../store/instance'
+import { getI18nText } from '../../../../../utils/i18n'
 import SaveModal from './SaveModal.vue'
 
 const { t: $t } = useI18n()
@@ -147,7 +148,7 @@ const documentTypeText = (type: string) => (
 )
 
 const fileName = (record: Record<string, any>) => {
-  const fileId = String(record.fileId || '').split(/[?#]/)[0]
+  const fileId = String(getI18nText(record, 'fileId')).split(/[?#]/)[0]
   return fileId.split(/[\\/]/).pop() || fileId || '-'
 }
 
@@ -181,8 +182,9 @@ const openEdit = (record: Record<string, any>) => {
 }
 
 const openFile = (record: Record<string, any>) => {
-  if (record.fileId) {
-    window.open(getFileUrlById(String(record.fileId)), '_blank')
+  const fileId = getI18nText(record, 'fileId')
+  if (fileId) {
+    window.open(getFileUrlById(fileId), '_blank')
   }
 }
 

--- a/views/device/Instance/Save/index.vue
+++ b/views/device/Instance/Save/index.vue
@@ -72,8 +72,12 @@
                 }
               ]"
             >
-              <a-input
+              <I18nTextField
                 v-model:value="modelRef.name"
+                v-model:i18nMessages="modelRef.i18nMessages"
+                field="name"
+                :label="$t('Save.index.902471-6')"
+                :i18n-max-length="64"
                 :placeholder="$t('Save.index.902471-7')"
               />
             </a-form-item>
@@ -136,11 +140,15 @@
             }
           ]"
         >
-          <a-textarea
+          <I18nTextField
             v-model:value="modelRef.describe"
+            v-model:i18nMessages="modelRef.i18nMessages"
+            field="describe"
+            :label="$t('Save.index.902471-12')"
             :placeholder="$t('Save.index.902471-14')"
             showCount
             :maxlength="200"
+            textarea
           />
         </a-form-item>
       </a-form>
@@ -159,6 +167,7 @@ import { moduleRegistry } from '@jetlinks-web-core/utils/module-registry'
 import { deviceCloudSave } from '@device-manager-ui/api/instance'
 import { ensureVisualizationDashboardProject } from '@device-manager-ui/utils/dashboardProject'
 import {isSaaS} from "@jetlinks-web-core/utils/consts";
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue'
 
 const { t: $t } = useI18n()
 
@@ -183,6 +192,7 @@ const modelRef = reactive({
   id: undefined,
   name: '',
   describe: '',
+  i18nMessages: {} as Record<string, Record<string, string>>,
   configuration: {
     type: 'local'
   },

--- a/views/device/Instance/index.vue
+++ b/views/device/Instance/index.vue
@@ -9,7 +9,7 @@
             <JProTable
                 ref="instanceRef"
                 :columns="columns"
-                :request="query"
+                :request="queryWithProductI18n"
                 :defaultParams="{
                     sorts: [{ name: 'createTime', order: 'desc' }, { name: 'name', order: 'desc'}],
                 }"
@@ -80,7 +80,7 @@
                                 "
                             >
                                 <span style="font-size: 16px; font-weight: 600">
-                                    {{ slotProps.name }}
+                                    {{ getI18nText(slotProps, 'name') }}
                                 </span>
                             </j-ellipsis>
                             <a-row>
@@ -95,7 +95,7 @@
                                         {{ $t('Instance.index.133466-2') }}
                                     </div>
                                     <j-ellipsis style="width: 100%">
-                                        {{ slotProps.productName }}
+                                        {{ getI18nText(slotProps, 'productName') }}
                                     </j-ellipsis>
                                 </a-col>
                             </a-row>
@@ -132,6 +132,15 @@
                             notActive: 'warning',
                         }"
                     />
+                </template>
+                <template #name="slotProps">
+                    {{ getI18nText(slotProps, 'name') }}
+                </template>
+                <template #describe="slotProps">
+                    {{ getI18nText(slotProps, 'describe') }}
+                </template>
+                <template #productName="slotProps">
+                    {{ getI18nText(slotProps, 'productName') }}
                 </template>
                 <template #createTime="slotProps">
                     <span>{{
@@ -203,7 +212,7 @@
 
 <script setup lang="ts">
 import {
-    query,
+    queryWithProductI18n,
     _delete,
     _deploy,
     _undeploy,
@@ -238,6 +247,7 @@ import { useTermOptions } from '@jetlinks-web/components/es/Search/hooks/useTerm
 import { mergeObjectArrays, getBaseApi } from '@jetlinks-web-core/utils';
 import {deviceStateList} from "@device-manager-ui/views/device/data";
 import {isSaaS} from '@jetlinks-web-core/utils/consts'
+import { getI18nText } from '../../../utils/i18n'
 
 const { t: $t } = useI18n();
 
@@ -291,6 +301,7 @@ const columns = ref([
         title: $t('Instance.index.133466-4'),
         dataIndex: 'name',
         key: 'name',
+        scopedSlots: true,
         ellipsis: true,
         search: {
             type: 'string',
@@ -301,6 +312,7 @@ const columns = ref([
         title: $t('Instance.index.133466-2'),
         dataIndex: 'productName',
         key: 'productName',
+        scopedSlots: true,
         ellipsis: true,
         search: {
             type: 'select',
@@ -310,7 +322,7 @@ const columns = ref([
                     queryNoPagingPost({ paging: false }).then((resp: any) => {
                         resolve(
                             resp.result.map((item: any) => ({
-                                label: item.name,
+                                label: getI18nText(item, 'name'),
                                 value: item.id,
                             })),
                         );

--- a/views/device/Instance/typings.d.ts
+++ b/views/device/Instance/typings.d.ts
@@ -3,10 +3,13 @@ import { MetadataItem } from "../Product/typings";
 export type DeviceInstance = {
   id: string;
   name: string;
+  i18nName?: string;
   describe: string;
+  i18nDescribe?: string;
   description: string;
   productId: string;
   productName: string;
+  i18nProductName?: string;
   protocolName: string;
   security: any;
   deriveMetadata: string;

--- a/views/device/Product/Detail/BasicInfo/index.vue
+++ b/views/device/Product/Detail/BasicInfo/index.vue
@@ -21,7 +21,7 @@
             <j-ellipsis>{{ productStore.current.id }}</j-ellipsis>
         </a-descriptions-item>
         <a-descriptions-item :label="$t('BasicInfo.indev.028379-1')">
-            <j-ellipsis>{{ productStore.current.classifiedName }}</j-ellipsis>
+            <j-ellipsis>{{ getI18nText(productStore.current, 'classifiedName') }}</j-ellipsis>
         </a-descriptions-item>
         <a-descriptions-item :label="$t('BasicInfo.indev.028379-2')">{{
             productStore.current.deviceType?.text
@@ -35,8 +35,8 @@
                     >
                     <div style="white-space: normal">
                     <j-ellipsis>{{
-                        productStore.current.accessName
-                            ? productStore.current.accessName
+                        getI18nText(productStore.current, 'accessName')
+                            ? getI18nText(productStore.current, 'accessName')
                             : $t('BasicInfo.indev.028379-4')
                     }}</j-ellipsis>
                     </div>
@@ -51,7 +51,7 @@
         }}</a-descriptions-item>
 
         <a-descriptions-item :label="$t('BasicInfo.indev.028379-7')" :span="3">
-            {{ productStore.current.describe }}
+            {{ getI18nText(productStore.current, 'describe') }}
         </a-descriptions-item>
     </a-descriptions>
 
@@ -66,6 +66,7 @@ import dayjs from 'dayjs';
 import { useRoute } from 'vue-router';
 import { useMenuStore } from '@jetlinks-web-core/store/menu';
 import { useI18n } from 'vue-i18n';
+import { getI18nText } from '../../../../../utils/i18n'
 
 const { t: $t } = useI18n();
 

--- a/views/device/Product/Detail/DeviceAccess/index.vue
+++ b/views/device/Product/Detail/DeviceAccess/index.vue
@@ -40,11 +40,11 @@
         </Title>
         <div>
           <div>
-            {{ access?.name }}
+            {{ getI18nText(access, 'name') }}
           </div>
           <div>
             {{
-              access?.description ||
+              getI18nText(access, 'description') ||
               dataSource.find((item) => item?.id === access?.provider)
                 ?.description
             }}
@@ -55,7 +55,7 @@
               <a-collapse v-model:activeKey="activeKey">
                 <a-collapse-panel
                   v-for="item in access?.configuration?.gateways"
-                  :key="item.id" :header="item.name"
+                  :key="item.id" :header="getI18nText(item, 'name')"
                 >
                   <template #extra>
                     {{ dataSource.find((i) => i?.id === item?.provider)?.description }}
@@ -63,7 +63,7 @@
                   <div class="item-style">
                     <Title :data="$t('DeviceAccess.index.594346-6')"></Title>
                     <div>
-                      {{ item?.protocolDetail?.name }}
+                      {{ getI18nText(item?.protocolDetail, 'name') }}
                     </div>
                   </div>
                   <div class="item-style">
@@ -130,7 +130,7 @@
           <div class="item-style">
             <Title :data="$t('DeviceAccess.index.594346-6')"></Title>
             <div>
-              {{ access?.protocolDetail?.name }}
+              {{ getI18nText(access?.protocolDetail, 'name') }}
             </div>
           </div>
           <div class="item-style">
@@ -293,6 +293,7 @@ import {onlyMessage} from "@jetlinks-web-core/utils/comm";
 import {pick} from "lodash-es";
 import {useI18n} from "vue-i18n";
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import { getI18nText } from '../../../../../utils/i18n'
 
 const { t: $t } = useI18n();
 const route = useRoute();

--- a/views/device/Product/Detail/index.vue
+++ b/views/device/Product/Detail/index.vue
@@ -9,9 +9,9 @@
       <div>
         <div style="display: flex; align-items: center">
           <a-tooltip>
-            <template #title>{{ productStore.current.name }}</template>
+            <template #title>{{ getI18nText(productStore.current, 'name') }}</template>
             <div class="productDetailHead">
-              {{ productStore.current.name }}
+              {{ getI18nText(productStore.current, 'name') }}
             </div>
           </a-tooltip>
           <div
@@ -122,6 +122,7 @@ import { isNoCommunity } from '@jetlinks-web-core/utils/utils'
 import { useI18n } from 'vue-i18n'
 import { tabs } from './asyncComponent'
 import { isApplyDashboard } from '@device-manager-ui/utils/dashboardProject'
+import { getI18nText } from '../../../../utils/i18n'
 
 const { t: $t } = useI18n()
 

--- a/views/device/Product/Save/index.vue
+++ b/views/device/Product/Save/index.vue
@@ -52,8 +52,12 @@
                             />
                         </a-form-item>
                         <a-form-item :label="$t('Save.index.912481-4')" name="name">
-                            <a-input
+                            <I18nTextField
                                 v-model:value="form.name"
+                                v-model:i18nMessages="form.i18nMessages"
+                                field="name"
+                                :label="$t('Save.index.912481-4')"
+                                :i18n-max-length="64"
                                 :placeholder="$t('Save.index.912481-5')"
                             />
                         </a-form-item>
@@ -116,13 +120,17 @@
                     </div>
                 </RegistryComponent>
                 
-                <a-form-item :label="$t('Save.index.912481-9')" name="description">
-                    <a-textarea
+                <a-form-item :label="$t('Save.index.912481-9')" name="describe">
+                    <I18nTextField
                         :maxlength="200"
                         showCount
                         :auto-size="{ minRows: 4, maxRows: 5 }"
                         v-model:value="form.describe"
+                        v-model:i18nMessages="form.i18nMessages"
+                        field="describe"
+                        :label="$t('Save.index.912481-9')"
                         :placeholder="$t('Save.index.912481-10')"
+                        textarea
                     />
                 </a-form-item>
             </a-form>
@@ -150,6 +158,7 @@ import { useI18n } from 'vue-i18n';
 import { omit } from 'lodash-es';
 import SaveProductCloud from './SaveProductCloud.vue';
 import { ensureVisualizationDashboardProject } from '@device-manager-ui/utils/dashboardProject';
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 
@@ -220,7 +229,8 @@ const form = reactive({
     type: 'custom',
     masterProductId: undefined,
     edgeMasterId: undefined,
-    metadata: undefined
+    metadata: undefined,
+    i18nMessages: {} as Record<string, Record<string, string>>,
 });
 /**
  * 校验id
@@ -284,7 +294,7 @@ const rules = reactive({
             validator: validateDeviceType,
         },
     ],
-    description: [
+    describe: [
         { max: 200, message: $t('Save.index.912481-21'), trigger: 'blur' },
     ],
     type: [
@@ -342,6 +352,7 @@ const show = async (data: any) => {
         form.photoUrl = data.photoUrl || photoValue.value;
         form.deviceType = data.deviceType.value;
         form.describe = data.describe;
+        form.i18nMessages = data.i18nMessages || {};
         form.id = data.id;
         idDisabled.value = true;
         form.type =
@@ -374,6 +385,7 @@ const show = async (data: any) => {
         form.photoUrl = device.deviceProduct;
         form.deviceType = '';
         form.describe = undefined;
+        form.i18nMessages = {};
         form.id = undefined;
         idDisabled.value = false;
         form.type = 'custom';

--- a/views/device/Product/index.vue
+++ b/views/device/Product/index.vue
@@ -76,7 +76,7 @@
             <template #content>
               <j-ellipsis style="width: calc(100% - 100px); margin-bottom: 18px"
                 ><span style="font-weight: 600; font-size: 16px">
-                  {{ slotProps.name }}
+                  {{ getI18nText(slotProps, 'name') }}
                 </span></j-ellipsis
               >
               <a-row>
@@ -93,8 +93,8 @@
                   <j-ellipsis>
                     <div>
                       {{
-                        slotProps?.accessName
-                          ? slotProps?.accessName
+                        getI18nText(slotProps, 'accessName')
+                          ? getI18nText(slotProps, 'accessName')
                           : $t("Product.index.660348-6")
                       }}
                     </div>
@@ -136,6 +136,15 @@
               0: 'error',
             }"
           />
+        </template>
+        <template #name="slotProps">
+          {{ getI18nText(slotProps, 'name') }}
+        </template>
+        <template #accessName="slotProps">
+          {{ getI18nText(slotProps, 'accessName') || $t('Product.index.660348-6') }}
+        </template>
+        <template #describe="slotProps">
+          {{ getI18nText(slotProps, 'describe') }}
         </template>
         <template #action="slotProps">
           <a-space>
@@ -197,6 +206,7 @@ import { useI18n } from "vue-i18n";
 import { useTermOptions } from '@jetlinks-web/components/es/Search/hooks/useTermOptions'
 import BatchDropdown from "@jetlinks-web-core/components/BatchDropdown/index.vue";
 import {isSaaS} from '@jetlinks-web-core/utils/consts'
+import { getI18nText } from '../../../utils/i18n'
 
 const { t: $t } = useI18n();
 
@@ -224,6 +234,7 @@ const columns = [
     title: $t("Product.index.660348-7"),
     dataIndex: "name",
     key: "name",
+    scopedSlots: true,
     width: 220,
     ellipsis: true,
   },
@@ -231,6 +242,7 @@ const columns = [
     title: $t("Product.index.660348-5"),
     dataIndex: "accessName",
     key: "accessName",
+    scopedSlots: true,
     width: 220,
     ellipsis: true,
   },
@@ -266,6 +278,7 @@ const columns = [
     title: $t("Product.index.660348-10"),
     dataIndex: "describe",
     key: "describe",
+    scopedSlots: true,
     ellipsis: true,
   },
   {

--- a/views/device/Product/typings.d.ts
+++ b/views/device/Product/typings.d.ts
@@ -8,8 +8,10 @@ type DeviceType = {
 export type ProductItem = {
   id: string;
   name: string;
+  i18nName?: string;
   classifiedId: string | string[];
   classifiedName: string;
+  i18nClassifiedName?: string;
   configuration: Record<string, any>;
   createTime: number;
   updateTime: number;
@@ -21,11 +23,18 @@ export type ProductItem = {
   metadata: string;
   orgId: string;
   protocolName: string;
+  i18nProtocolName?: string;
   state: number;
   transportProtocol: string;
   describe?: string;
+  i18nDescribe?: string;
   accessId?: string;
   accessName?: string;
+  i18nAccessName?: string;
+  manufacturer?: string;
+  i18nManufacturer?: string;
+  model?: string;
+  i18nModel?: string;
   photoUrl?: string;
   storePolicy?: string;
   accessProvider?: string;

--- a/views/link/AccessConfig/components/Channel/index.vue
+++ b/views/link/AccessConfig/components/Channel/index.vue
@@ -27,16 +27,24 @@
                                 },
                             ]"
                         >
-                            <a-input
+                            <I18nTextField
                                 :placeholder="$t('Channel.index.456223-2')"
                                 v-model:value="formState.name"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="name"
+                                :label="$t('Channel.index.456223-1')"
+                                :i18n-max-length="64"
                             />
                         </a-form-item>
                         <a-form-item :label="$t('Channel.index.456223-4')" name="description">
-                            <a-textarea
+                            <I18nTextField
                                 :placeholder="$t('Channel.index.456223-5')"
                                 :rows="4"
                                 v-model:value="formState.description"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="description"
+                                :label="$t('Channel.index.456223-4')"
+                                textarea
                                 show-count
                                 :maxlength="200"
                             />
@@ -82,11 +90,13 @@ import { update, save } from '../../../../../api/link/accessConfig';
 import { ProtocolMapping } from '../../data';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 interface FormState {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -109,6 +119,7 @@ const type = ref(props.provider.type || props.data.type);
 const formState = ref<FormState>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 
 const { onBack } = useTabSaveSuccessBack()

--- a/views/link/AccessConfig/components/Cloud/Ctwing.vue
+++ b/views/link/AccessConfig/components/Cloud/Ctwing.vue
@@ -270,16 +270,24 @@
                                 },
                             ]"
                         >
-                            <a-input
+                            <I18nTextField
                                 :placeholder="$t('Cloud.Ctwing.076179-28')"
                                 v-model:value="formData.name"
+                                v-model:i18nMessages="formData.i18nMessages"
+                                field="name"
+                                :label="$t('Cloud.Ctwing.076179-27')"
+                                :i18n-max-length="64"
                             />
                         </a-form-item>
                         <a-form-item :label="$t('Cloud.Ctwing.076179-5')" name="description">
-                            <a-textarea
+                            <I18nTextField
                                 :placeholder="$t('Cloud.Ctwing.076179-6')"
                                 :rows="4"
                                 v-model:value="formData.description"
+                                v-model:i18nMessages="formData.i18nMessages"
+                                field="description"
+                                :label="$t('Cloud.Ctwing.076179-5')"
+                                textarea
                                 show-count
                                 :maxlength="200"
                             />
@@ -354,6 +362,7 @@ import { useMenuStore } from '@jetlinks-web-core/store/menu';
 import { network } from '../../../../../assets';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccess, useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const menuStory = useMenuStore();
@@ -374,6 +383,7 @@ interface FormState {
 interface Form {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -407,6 +417,7 @@ const formState = ref<FormState>({
 const formData = ref<Form>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 
 const showAddBtn = computed(() => {

--- a/views/link/AccessConfig/components/Cloud/OneNet.vue
+++ b/views/link/AccessConfig/components/Cloud/OneNet.vue
@@ -348,16 +348,24 @@
                                     },
                                 ]"
                             >
-                                <a-input
+                                <I18nTextField
                                     :placeholder="$t('Cloud.OneNet.808542-42')"
                                     v-model:value="formData.name"
+                                    v-model:i18nMessages="formData.i18nMessages"
+                                    field="name"
+                                    :label="$t('Cloud.OneNet.808542-41')"
+                                    :i18n-max-length="64"
                                 />
                             </a-form-item>
                             <a-form-item :label="$t('Cloud.OneNet.808542-10')" name="description">
-                                <a-textarea
+                                <I18nTextField
                                     :placeholder="$t('Cloud.OneNet.808542-11')"
                                     :rows="4"
                                     v-model:value="formData.description"
+                                    v-model:i18nMessages="formData.i18nMessages"
+                                    field="description"
+                                    :label="$t('Cloud.OneNet.808542-10')"
+                                    textarea
                                     show-count
                                     :maxlength="200"
                                 />
@@ -433,6 +441,7 @@ import { useMenuStore } from '@jetlinks-web-core/store';
 import { network } from '../../../../../assets';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccess, useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const menuStory = useMenuStore();
@@ -453,6 +462,7 @@ interface FormState {
 interface Form {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 
 const props = defineProps({
@@ -487,6 +497,7 @@ const formState = ref<FormState>({
 const formData = ref<Form>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 
 const loading = ref(false)

--- a/views/link/AccessConfig/components/Composite/index.vue
+++ b/views/link/AccessConfig/components/Composite/index.vue
@@ -161,15 +161,26 @@
                   { max: 64, message: $t('Composite.index.636069-6') },
                 ]"
               >
-                <a-input v-model:value="formData.name" :placeholder="$t('Composite.index.636069-5')"></a-input>
+                <I18nTextField
+                  v-model:value="formData.name"
+                  v-model:i18nMessages="formData.i18nMessages"
+                  field="name"
+                  :label="$t('Composite.index.636069-4')"
+                  :i18n-max-length="64"
+                  :placeholder="$t('Composite.index.636069-5')"
+                />
               </a-form-item>
               <a-form-item :label="$t('Composite.index.636069-7')">
-                <a-textarea
+                <I18nTextField
                   v-model:value="formData.description"
+                  v-model:i18nMessages="formData.i18nMessages"
+                  field="description"
+                  :label="$t('Composite.index.636069-7')"
+                  textarea
                   showCount
                   :rows="4"
                   :maxlength="200"
-                ></a-textarea>
+                />
               </a-form-item>
             </a-form>
           </a-col>
@@ -314,6 +325,7 @@ import Outline from '../../Outline/index.vue'
 import { BackMap } from '../../data'
 import { useI18n } from 'vue-i18n'
 import { useTabSaveSuccess } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue'
 
 const { t: $t } = useI18n()
 const props = defineProps({
@@ -350,6 +362,7 @@ const formData = reactive({
   id: route.params.id !== ':id' ? route.params.id : generateId,
   name: '',
   description: '',
+  i18nMessages: {},
 })
 
 const { onOpen } = useTabSaveSuccess('link/AccessConfig/Detail', {

--- a/views/link/AccessConfig/components/Edge/geteway.vue
+++ b/views/link/AccessConfig/components/Edge/geteway.vue
@@ -27,14 +27,22 @@
               :label="$t('Edge.geteway.598238-3')"
               name="name"
             >
-              <a-input
+              <I18nTextField
                 v-model:value="formState.name"
+                v-model:i18nMessages="formState.i18nMessages"
+                field="name"
+                :label="$t('Edge.geteway.598238-0')"
+                :i18n-max-length="64"
                 :placeholder="$t('Edge.geteway.598238-1')"
               />
             </a-form-item>
             <a-form-item :label="$t('Edge.geteway.598238-4')" name="description">
-              <a-textarea
+              <I18nTextField
                 v-model:value="formState.description"
+                v-model:i18nMessages="formState.i18nMessages"
+                field="description"
+                :label="$t('Edge.geteway.598238-4')"
+                textarea
                 :maxlength="200"
                 :rows="4"
                 :placeholder="$t('Edge.geteway.598238-5')"
@@ -82,11 +90,13 @@ import { update, save } from "../../../../../api/link/accessConfig";
 import { ProtocolMapping } from "../../data";
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 interface FormState {
   name: string;
   description: string;
+  i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -109,6 +119,7 @@ const type = ref(props.provider.type || props.data.type);
 const formState = ref<FormState>({
   name: "",
   description: "",
+  i18nMessages: {},
 });
 const { onBack } = useTabSaveSuccessBack()
 

--- a/views/link/AccessConfig/components/Edge/index.vue
+++ b/views/link/AccessConfig/components/Edge/index.vue
@@ -134,16 +134,24 @@
                                 },
                             ]"
                         >
-                            <a-input
+                            <I18nTextField
                                 :placeholder="$t('Edge.index.066653-8')"
                                 v-model:value="formState.name"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="name"
+                                :label="$t('Edge.index.066653-7')"
+                                :i18n-max-length="64"
                             />
                         </a-form-item>
                         <a-form-item :label="$t('Edge.index.066653-10')" name="description">
-                            <a-textarea
+                            <I18nTextField
                                 :placeholder="$t('Edge.index.066653-11')"
                                 :rows="4"
                                 v-model:value="formState.description"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="description"
+                                :label="$t('Edge.index.066653-10')"
+                                textarea
                                 show-count
                                 :maxlength="200"
                             />
@@ -216,6 +224,7 @@ import AccessCard from '../AccessCard/index.vue';
 import { useMenuStore } from '@jetlinks-web-core/store/menu';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccess, useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const menuStory = useMenuStore();
@@ -223,6 +232,7 @@ const menuStory = useMenuStore();
 interface FormState {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -246,6 +256,7 @@ const channel = ref(props.provider.channel);
 const formState = ref<FormState>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 
 const formRef = ref<FormInstance>();

--- a/views/link/AccessConfig/components/Media/GB28181.vue
+++ b/views/link/AccessConfig/components/Media/GB28181.vue
@@ -390,8 +390,12 @@
                     :label="$t('Media.GB28181.666483-27')"
                     v-bind="validateInfos.name"
                   >
-                    <a-input
+                    <I18nTextField
                       v-model:value="formData.name"
+                      v-model:i18nMessages="formData.i18nMessages"
+                      field="name"
+                      :label="$t('Media.GB28181.666483-27')"
+                      :i18n-max-length="64"
                       allowClear
                       :placeholder="$t('Media.GB28181.666483-28')"
                     />
@@ -401,10 +405,14 @@
                     :label="$t('Media.GB28181.666483-29')"
                     v-bind="validateInfos.description"
                   >
-                    <a-textarea
+                    <I18nTextField
                       :placeholder="$t('Media.GB28181.666483-30')"
                       :rows="4"
                       v-model:value="formData.description"
+                      v-model:i18nMessages="formData.i18nMessages"
+                      field="description"
+                      :label="$t('Media.GB28181.666483-29')"
+                      textarea
                       show-count
                       :maxlength="200"
                     />
@@ -489,6 +497,7 @@ import type { Rule } from 'ant-design-vue/es/form'
 import { testIpv4_6 } from '@jetlinks-web-core/utils/validate'
 import { useI18n } from 'vue-i18n'
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue'
 
 const { t: $t } = useI18n()
 interface Form2 {
@@ -538,7 +547,8 @@ const stepCurrent = ref(0)
 const steps = ref([$t('Media.GB28181.666483-36'), $t('Media.GB28181.666483-37')])
 const formData = ref({
   name: '',
-  description: ''
+  description: '',
+  i18nMessages: {},
 })
 let formState = ref<FormState>({
   domain: undefined,

--- a/views/link/AccessConfig/components/Media/Onvif.vue
+++ b/views/link/AccessConfig/components/Media/Onvif.vue
@@ -27,16 +27,24 @@
                                 },
                             ]"
                         >
-                            <a-input
+                            <I18nTextField
                                 :placeholder="$t('Media.Onvif.507446-2')"
                                 v-model:value="formState.name"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="name"
+                                :label="$t('Media.Onvif.507446-1')"
+                                :i18n-max-length="64"
                             />
                         </a-form-item>
                         <a-form-item :label="$t('Media.Onvif.507446-4')" name="description">
-                            <a-textarea
+                            <I18nTextField
                                 :placeholder="$t('Media.Onvif.507446-5')"
                                 :rows="4"
                                 v-model:value="formState.description"
+                                v-model:i18nMessages="formState.i18nMessages"
+                                field="description"
+                                :label="$t('Media.Onvif.507446-4')"
+                                textarea
                                 show-count
                                 :maxlength="200"
                             />
@@ -78,11 +86,13 @@ import { onlyMessage } from '@jetlinks-web/utils';
 import { update, save } from '../../../../../api/link/accessConfig';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 interface FormState {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -104,6 +114,7 @@ const channel = ref(props.provider.channel);
 const formState = ref<FormState>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 
 const { onBack } = useTabSaveSuccessBack()

--- a/views/link/AccessConfig/components/Media/index.vue
+++ b/views/link/AccessConfig/components/Media/index.vue
@@ -28,16 +28,24 @@
                                     },
                                 ]"
                             >
-                                <a-input
+                                <I18nTextField
                                     :placeholder="$t('Media.index.962215-2')"
                                     v-model:value="formState.name"
+                                    v-model:i18nMessages="formState.i18nMessages"
+                                    field="name"
+                                    :label="$t('Media.index.962215-1')"
+                                    :i18n-max-length="64"
                                 />
                             </a-form-item>
                             <a-form-item :label="$t('Media.index.962215-4')" name="description">
-                                <a-textarea
+                                <I18nTextField
                                     :placeholder="$t('Media.index.962215-5')"
                                     :rows="4"
                                     v-model:value="formState.description"
+                                    v-model:i18nMessages="formState.i18nMessages"
+                                    field="description"
+                                    :label="$t('Media.index.962215-4')"
+                                    textarea
                                     show-count
                                     :maxlength="200"
                                 />
@@ -99,11 +107,13 @@ import Plugin from '../Plugin/index.vue';
 import { update, save } from '../../../../../api/link/accessConfig';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 interface FormState {
     name: string;
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }
 const route = useRoute();
 const view = route.query.view as string;
@@ -130,6 +140,7 @@ const channel = ref(props.provider.channel);
 const formState = ref<FormState>({
     name: '',
     description: '',
+    i18nMessages: {},
 });
 const { onBack } = useTabSaveSuccessBack()
 

--- a/views/link/AccessConfig/components/Network/index.vue
+++ b/views/link/AccessConfig/components/Network/index.vue
@@ -135,8 +135,12 @@
                   :label="$t('Network.index.041705-8')"
                   v-bind="validateInfos.name"
                 >
-                  <a-input
+                  <I18nTextField
                     v-model:value="formData.name"
+                    v-model:i18nMessages="formData.i18nMessages"
+                    field="name"
+                    :label="$t('Network.index.041705-8')"
+                    :i18n-max-length="64"
                     allowClear
                     :placeholder="$t('Network.index.041705-9')"
                   />
@@ -145,10 +149,14 @@
                   :label="$t('Network.index.041705-10')"
                   v-bind="validateInfos.description"
                 >
-                  <a-textarea
+                  <I18nTextField
                     :placeholder="$t('Network.index.041705-11')"
                     :rows="4"
                     v-model:value="formData.description"
+                    v-model:i18nMessages="formData.i18nMessages"
+                    field="description"
+                    :label="$t('Network.index.041705-10')"
+                    textarea
                     show-count
                     :maxlength="200"
                   />
@@ -264,6 +272,7 @@ import { useMenuStore } from "@jetlinks-web-core/store/menu";
 import { onlyMessage, randomString } from "@jetlinks-web/utils";
 import { useI18n } from "vue-i18n";
 import { useTabSaveSuccess, useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const menuStory = useMenuStore();
@@ -321,6 +330,7 @@ const columnsHTTP = ref(<TableColumnType>[]);
 const formData = ref({
   name: "",
   description: "",
+  i18nMessages: {},
 });
 const loading = ref(false);
 

--- a/views/link/AccessConfig/components/Plugin/index.vue
+++ b/views/link/AccessConfig/components/Plugin/index.vue
@@ -104,8 +104,12 @@
                                     ]"
                                     name="name"
                                 >
-                                    <a-input
+                                    <I18nTextField
                                         v-model:value="formData.name"
+                                        v-model:i18nMessages="formData.i18nMessages"
+                                        field="name"
+                                        :label="$t('Plugin.index.626239-8')"
+                                        :i18n-max-length="64"
                                         allowClear
                                         :placeholder="$t('Plugin.index.626239-9')"
                                     />
@@ -120,10 +124,14 @@
                                     ]"
                                     name="description"
                                 >
-                                    <a-textarea
+                                    <I18nTextField
                                         :placeholder="$t('Plugin.index.626239-13')"
                                         :rows="4"
                                         v-model:value="formData.description"
+                                        v-model:i18nMessages="formData.i18nMessages"
+                                        field="description"
+                                        :label="$t('Plugin.index.626239-11')"
+                                        textarea
                                         show-count
                                         :maxlength="200"
                                     />
@@ -198,6 +206,7 @@ import { onlyMessage } from '@jetlinks-web-core/utils/comm';
 import { CreteRuleByType } from '../../../components/Form/rules';
 import { useI18n } from 'vue-i18n';
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const props = defineProps({
@@ -229,6 +238,7 @@ const loading = ref(false);
 const formData = reactive({
     name: undefined,
     description: undefined,
+    i18nMessages: {},
     configuration: {},
 });
 const formRef = ref();

--- a/views/link/AccessConfig/index.vue
+++ b/views/link/AccessConfig/index.vue
@@ -56,7 +56,7 @@
                                 <div class="card-item-content">
                                     <j-ellipsis style="width: calc(100% - 100px)">
                                         <span class="card-title">
-                                            {{ slotProps.name }}
+                                            {{ getI18nText(slotProps, 'name') }}
                                         </span>
                                     </j-ellipsis>
                                     <template v-if="slotProps.provider !== 'composite-device-gateway'">
@@ -128,8 +128,10 @@
                                                 >
                                                     <div>
                                                         {{
-                                                            slotProps.protocolDetail
-                                                                .name
+                                                            getI18nText(
+                                                                slotProps.protocolDetail,
+                                                                'name',
+                                                            )
                                                         }}
                                                     </div>
                                                 </j-ellipsis>
@@ -222,6 +224,7 @@ import { cloneDeep } from 'lodash-es';
 import Outline from './Outline/index.vue'
 import { device } from '../../../assets'
 import { useI18n } from 'vue-i18n';
+import { getI18nText } from '../../../utils/i18n';
 
 const { t: $t } = useI18n();
 const menuStory = useMenuStore();
@@ -393,8 +396,8 @@ const handleEye = (data: any) => {
 };
 
 const getDescription = (slotProps: Record<string, any>) =>
-    slotProps.description
-        ? slotProps.description
+    getI18nText(slotProps, 'description')
+        ? getI18nText(slotProps, 'description')
         : providersList.value?.find(
               (item: Record<string, any>) => item.id === slotProps.provider,
           )?.description;

--- a/views/link/Protocol/Save/index.vue
+++ b/views/link/Protocol/Save/index.vue
@@ -22,9 +22,13 @@
                     { max: 64, message: $t('Save.index.903552-4') },
                 ]"
             >
-                <a-input
+                <I18nTextField
                     :placeholder="$t('Save.index.903552-3')"
                     v-model:value="formData.name"
+                    v-model:i18nMessages="formData.i18nMessages"
+                    field="name"
+                    :label="$t('Save.index.903552-2')"
+                    :i18n-max-length="64"
                 />
             </a-form-item>
             <a-form-item
@@ -95,9 +99,13 @@
                 </a-button>
             </a-form-item>
             <a-form-item :label="$t('Save.index.903552-9')" name="description">
-                <a-textarea
+                <I18nTextField
                     :placeholder="$t('Save.index.903552-10')"
                     v-model:value="formData.description"
+                    v-model:i18nMessages="formData.i18nMessages"
+                    field="description"
+                    :label="$t('Save.index.903552-9')"
+                    textarea
                     :maxlength="200"
                     :rows="3"
                     showCount
@@ -141,6 +149,7 @@ import { useProtocolTypeProviders } from '../useProtocolTypeProviders';
 import { protocolTypeFontIcon } from '../protocolTypeAssets';
 import { PROTOCOL_TYPE_ORDER } from '../protocolTypes';
 import { cloneDeep } from 'lodash-es';
+import I18nTextField from '../../../../components/I18n/I18nTextField.vue';
 
 const { t: $t } = useI18n();
 const loading = ref(false);
@@ -192,6 +201,7 @@ const formData = ref<FormDataType>({
         location: '',
     },
     description: '',
+    i18nMessages: {},
 });
 
 const locationRules = computed(() => {
@@ -223,6 +233,7 @@ function createEmptyFormData(): FormDataType {
             location: '',
         },
         description: '',
+        i18nMessages: {},
     };
 }
 
@@ -335,6 +346,7 @@ const onSubmit = async () => {
     const payload = {
         name: data.name,
         description: data.description,
+        i18nMessages: formData.value.i18nMessages,
         type,
         configuration: data.configuration ?? formData.value.configuration,
     };

--- a/views/link/Protocol/index.vue
+++ b/views/link/Protocol/index.vue
@@ -50,7 +50,7 @@
                                                 font-weight: 600;
                                             "
                                         >
-                                            {{ slotProps.name }}
+                                            {{ getI18nText(slotProps, 'name') }}
                                         </span>
                                     </j-ellipsis>
                                     <a-row class="card-item-content-box">
@@ -145,6 +145,12 @@
                             </template>
                         </a-space>
                     </template>
+                    <template #name="slotProps">
+                        {{ getI18nText(slotProps, 'name') }}
+                    </template>
+                    <template #description="slotProps">
+                        {{ getI18nText(slotProps, 'description') }}
+                    </template>
                 </j-pro-table>
             </FullPage>
         </div>
@@ -161,6 +167,7 @@ import { useI18n } from 'vue-i18n';
 import { computed } from 'vue';
 import { useProtocolTypeProviders } from './useProtocolTypeProviders';
 import { protocolTypeFontIcon } from './protocolTypeAssets';
+import { getI18nText } from '../../../utils/i18n';
 
 const { t: $t } = useI18n();
 const { typeFilterOptions, typeLabel } = useProtocolTypeProviders();
@@ -204,6 +211,7 @@ const columns = computed(() => [
         search: {
             type: 'string',
         },
+        scopedSlots: true,
         ellipsis: true,
     },
     {
@@ -223,6 +231,7 @@ const columns = computed(() => [
         search: {
             type: 'string',
         },
+        scopedSlots: true,
         ellipsis: true,
     },
     {

--- a/views/link/Protocol/type.d.ts
+++ b/views/link/Protocol/type.d.ts
@@ -8,4 +8,5 @@ export interface FormDataType {
         pkgVersion?: string;
     };
     description: string;
+    i18nMessages?: Record<string, Record<string, string>>;
 }

--- a/views/link/Type/Detail/index.vue
+++ b/views/link/Type/Detail/index.vue
@@ -12,8 +12,12 @@
           <a-row :gutter="[24, 0]">
             <a-col :span="12">
               <a-form-item :label="$t('Detail.index.258513-0')" name="name" :rules="Rules.name">
-                <a-input
+                <I18nTextField
                   v-model:value="formData.name"
+                  v-model:i18nMessages="formData.i18nMessages"
+                  field="name"
+                  :label="$t('Detail.index.258513-0')"
+                  :i18n-max-length="64"
                   :placeholder="$t('Detail.index.258513-1')"
                 />
               </a-form-item>
@@ -772,11 +776,15 @@
           <a-row :gutter="[24, 0]">
             <a-col :span="24">
               <a-form-item :label="$t('Detail.index.258513-62')" name="description">
-                <a-textarea
+                <I18nTextField
                   v-model:value="formData.description"
+                  v-model:i18nMessages="formData.i18nMessages"
+                  field="description"
+                  :label="$t('Detail.index.258513-62')"
                   show-count
                   :maxlength="200"
                   :rows="4"
+                  textarea
                 /> </a-form-item
             ></a-col>
           </a-row>
@@ -834,6 +842,7 @@ import { storeToRefs } from "pinia";
 import NodeSelect from "./NodeSelect.vue";
 import { useI18n } from "vue-i18n";
 import { useTabSaveSuccessBack } from '@jetlinks-web-core/hooks'
+import I18nTextField from '@device-manager-ui/components/I18n/I18nTextField.vue'
 
 const { t: $t } = useI18n();
 const route = useRoute();

--- a/views/link/Type/data.ts
+++ b/views/link/Type/data.ts
@@ -33,6 +33,7 @@ export const FormStates = {
     type: '',
     shareCluster: true,
     description: '',
+    i18nMessages: {},
 };
 
 export const FormStates2 = {

--- a/views/link/Type/index.vue
+++ b/views/link/Type/index.vue
@@ -66,7 +66,7 @@
                                                 line-height: 22px;
                                             "
                                         >
-                                            {{ slotProps.name }}
+                                            {{ getI18nText(slotProps, 'name') }}
                                         </span>
                   </j-ellipsis>
                   <a-row class="card-item-content-box">
@@ -165,6 +165,12 @@
                             }"
             ></j-badge-status>
           </template>
+          <template #name="slotProps">
+            {{ getI18nText(slotProps, 'name') }}
+          </template>
+          <template #description="slotProps">
+            {{ getI18nText(slotProps, 'description') }}
+          </template>
           <template #shareCluster="slotProps">
             {{
               slotProps.shareCluster === true
@@ -190,6 +196,7 @@ import {useMenuStore} from '@jetlinks-web-core/store';
 import {network} from "../../../assets";
 import {useI18n} from 'vue-i18n';
 import { isNoCommunity } from '@jetlinks-web-core/utils/utils';
+import { getI18nText } from '../../../utils/i18n'
 
 const {t: $t} = useI18n();
 const menuStory = useMenuStore();
@@ -208,6 +215,7 @@ const columns = [
     search: {
       type: 'string',
     },
+    scopedSlots: true,
   },
   {
     title: $t('Type.index.196842-1'),
@@ -254,6 +262,7 @@ const columns = [
     dataIndex: 'description',
     key: 'description',
     ellipsis: true,
+    scopedSlots: true,
     search: {
       type: 'string',
     },

--- a/views/link/Type/type.d.ts
+++ b/views/link/Type/type.d.ts
@@ -30,6 +30,7 @@ export interface FormDataType {
     type: string;
     shareCluster: boolean;
     description: string;
+    i18nMessages: Record<string, Record<string, string>>;
 }
 
 export interface TagsFilterType {


### PR DESCRIPTION
## 目的

- 使 SaaS 运行时设备管理页面支持设备、产品、产品分类、协议与接入配置等展示字段的国际化配置和展示。
- 统一复用国际化输入组件，保证中文、英文配置与当前界面语言展示一致。

## 核心变动

- `device-manager-ui`：新增通用国际化输入组件和展示取值工具，统一处理展示字段及 `i18nMessages` 的回显。
- `device-manager-ui`：产品、设备、产品分类、协议、设备接入网关及接入配置页面补充国际化按钮、弹窗和类型定义。
- `device-manager-ui`：设备列表、产品列表、详情、安装文档和接入配置按当前语言展示后端返回的国际化字段。
- `device-manager-ui`：补充中英文语言资源和设备安装流响应字段处理。

## 设计与测试目标

- 设计稿：不适用；沿用既有运行时设备管理页面和运营端国际化交互。
- 用户确认：已确认；页面交互已在联调过程中逐项验证。
- 测试目标：确保新增国际化组件、类型和页面引用可通过模块级生产构建。
- 前端质量：未新增页面壳层或路由；复用模块内国际化组件与现有设备管理页面结构。

## 测试结果

- 命令：`node --max_old_space_size=8192 --max-semi-space-size=64 ../node_modules/vite/bin/vite.js build -- --module-name device-manager-ui`（在 `jetlinks-web-core` 目录执行）
- 结果：构建通过，转换 7,576 个模块，耗时 1 分 41 秒。
- 自动化测试：未发现与本次页面国际化改动直接对应的前端单元测试脚本。
- 覆盖率：当前模块未配置前端覆盖率统计；以模块级生产构建和已完成的页面联调作为替代验证。

## 文档同步情况

- 未同步：无；不涉及模块长期说明、路由或接口文档变更。
- 说明：未新增任务流水文档。

## 风险与说明

- 影响范围：仅 `device-manager-ui` 子模块；未提交上层 `saas-runtime-ui` 工作区的其他模块、Docker、锁文件或子模块引用改动。
- 已知构建警告：现有资源路径、Rollup `input` 选项和大包体积警告仍存在，本次未引入新的构建错误。
- 未覆盖场景：未执行浏览器自动化 E2E；需要继续依赖运行时服务联调验证不同请求语言下的实际接口返回。