### PR TITLE
feat(设备监控): 扩展设备明细分页及范围筛选能力

### DIFF
--- a/api/deviceInstanceMonitoring.ts
+++ b/api/deviceInstanceMonitoring.ts
@@ -20,3 +20,8 @@ export const queryDeviceInstanceDetail = (
   {},
   config,
 )
+
+export const queryDeviceInstanceDetailPage = (
+  data: Record<string, unknown>,
+  config?: RequestConfig,
+) => request.post('/device/instance/detail/_query', data, config)

--- a/dataCapabilities/deviceInstanceMonitoring.service.ts
+++ b/dataCapabilities/deviceInstanceMonitoring.service.ts
@@ -1,14 +1,19 @@
 import i18n from '@jetlinks-web-core/locales'
 import {
   queryDeviceInstanceDetail,
+  queryDeviceInstanceDetailPage,
   queryDeviceInstanceStates,
 } from '@device-manager-ui/api/deviceInstanceMonitoring'
 import type {
   DeviceDetailData,
+  DeviceDetailPageData,
+  DeviceDetailPageQuery,
+  DeviceDetailPageRow,
   DeviceDetailQuery,
   DeviceStateBatchQuery,
   DeviceStateRow,
 } from './deviceInstanceMonitoring.types'
+import { createIotDeviceScopeTerm } from './deviceScope'
 
 type UnknownRecord = Record<string, unknown>
 
@@ -43,6 +48,38 @@ export async function loadDeviceDetail(
     throw new Error(t('DeviceInstanceDataCapability.error.loadFailed'))
   }
   return normalizeDeviceDetail(detail, query.deviceId)
+}
+
+export async function loadDeviceDetailPage(
+  query: DeviceDetailPageQuery,
+  signal?: AbortSignal,
+): Promise<DeviceDetailPageData> {
+  const terms: UnknownRecord[] = []
+  if (query.scope === 'iot') terms.push(createIotDeviceScopeTerm())
+  if (query.state) {
+    terms.push({ column: 'state', termType: 'eq', value: query.state })
+  }
+
+  const response = await queryDeviceInstanceDetailPage({
+    paging: true,
+    pageIndex: query.pageIndex,
+    pageSize: query.pageSize,
+    sorts: [{ name: 'createTime', order: 'desc' }],
+    terms,
+  }, { signal, hiddenError: true })
+  assertResponseSuccess(response)
+
+  const result = asRecord(unwrapResult(response))
+  const data = extractRows(result)
+    .map(normalizeDeviceDetailPageRow)
+    .filter((item): item is DeviceDetailPageRow => Boolean(item))
+
+  return {
+    data,
+    total: finiteNumber(result.total ?? result.count) ?? data.length,
+    pageIndex: finiteNumber(result.pageIndex) ?? query.pageIndex,
+    pageSize: finiteNumber(result.pageSize) ?? query.pageSize,
+  }
 }
 
 function normalizeStateRow(row: UnknownRecord): DeviceStateRow | undefined {
@@ -81,6 +118,33 @@ function normalizeDeviceDetail(
     ),
     address: textOrNull(row.address),
     description: firstText(row.description, row.describe),
+    lastActiveTime,
+  }
+}
+
+function normalizeDeviceDetailPageRow(
+  row: UnknownRecord,
+): DeviceDetailPageRow | undefined {
+  const deviceId = textOrNull(row.id)
+  if (!deviceId) return undefined
+
+  const state = enumValue(row.state)
+  const extensions = asRecord(row.extensions)
+  const iotExtensions = asRecord(extensions.iot)
+  const lastActiveTime = state === 'online'
+    ? toTimestamp(row.onlineTime)
+    : state === 'offline'
+      ? toTimestamp(row.offlineTime)
+      : state === 'notActive'
+        ? null
+        : toTimestamp(row.offlineTime) ?? toTimestamp(row.onlineTime)
+
+  return {
+    deviceId,
+    deviceName: textOrNull(row.name),
+    productName: textOrNull(row.productName),
+    state,
+    area: firstText(iotExtensions.area, extensions.area, row.orgName),
     lastActiveTime,
   }
 }
@@ -128,6 +192,12 @@ function toTimestamp(value: unknown): number | null {
   }
   const parsed = Date.parse(String(raw))
   return Number.isFinite(parsed) ? parsed : null
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  const number = Number(value)
+  return Number.isFinite(number) ? number : undefined
 }
 
 function textOrNull(value: unknown): string | null {

--- a/dataCapabilities/deviceInstanceMonitoring.types.ts
+++ b/dataCapabilities/deviceInstanceMonitoring.types.ts
@@ -1,3 +1,8 @@
+import type {
+  DeviceMonitoringScope,
+  DeviceMonitoringState,
+} from './deviceMonitoring.types'
+
 export interface DeviceStateBatchQuery {
   deviceIds: string[]
 }
@@ -24,4 +29,27 @@ export interface DeviceDetailData {
   address: string | null
   description: string | null
   lastActiveTime: number | null
+}
+
+export interface DeviceDetailPageQuery {
+  pageIndex: number
+  pageSize: number
+  state?: DeviceMonitoringState
+  scope?: DeviceMonitoringScope
+}
+
+export interface DeviceDetailPageRow {
+  deviceId: string
+  deviceName: string | null
+  productName: string | null
+  state: string | null
+  area: string | null
+  lastActiveTime: number | null
+}
+
+export interface DeviceDetailPageData {
+  data: DeviceDetailPageRow[]
+  total: number
+  pageIndex: number
+  pageSize: number
 }

--- a/dataCapabilities/deviceInstanceMonitoringProvider.ts
+++ b/dataCapabilities/deviceInstanceMonitoringProvider.ts
@@ -3,23 +3,37 @@ import type {
   DataCapabilityProvider,
   DataSourceDefinition,
   DataSourceRequest,
+  DataSourceResult,
   RuntimeContext,
 } from '@jetlinks-web-core/data-capability'
 import { defer, map } from 'rxjs'
 import {
   loadDeviceDetail,
+  loadDeviceDetailPage,
   loadDeviceStates,
 } from './deviceInstanceMonitoring.service'
 import type {
+  DeviceDetailPageData,
+  DeviceDetailPageQuery,
   DeviceDetailQuery,
   DeviceStateBatchQuery,
 } from './deviceInstanceMonitoring.types'
+import type {
+  DeviceMonitoringScope,
+  DeviceMonitoringState,
+} from './deviceMonitoring.types'
 
 const MODULE_ID = 'device-manager-ui'
 const PROVIDER_ID = 'device-manager:instance-monitoring'
 const STATE_BATCH_SOURCE_ID = 'device.state.batch'
 const DETAIL_SOURCE_ID = 'device.detail'
+const DETAIL_PAGE_SOURCE_ID = 'device.detail.page'
 const MAX_DEVICE_IDS = 200
+const DEFAULT_PAGE_INDEX = 0
+const DEFAULT_PAGE_SIZE = 10
+const MAX_PAGE_SIZE = 200
+const STATES: DeviceMonitoringState[] = ['online', 'offline', 'notActive']
+const SCOPES: DeviceMonitoringScope[] = ['iot']
 
 const owner = { moduleId: MODULE_ID, providerId: PROVIDER_ID }
 const t = (key: string) => String(i18n.global.t(key))
@@ -89,6 +103,40 @@ const detailSource: DataSourceDefinition = {
   }),
 }
 
+const detailPageSource: DataSourceDefinition = {
+  id: DETAIL_PAGE_SOURCE_ID,
+  kind: 'data-source',
+  version: 1,
+  name: t('DeviceInstanceDataCapability.detailPage.name'),
+  description: t('DeviceInstanceDataCapability.detailPage.description'),
+  owner,
+  tags: ['device', 'detail', 'page'],
+  facets: { category: 'device-instance-monitoring' },
+  modes: ['page', 'snapshot'],
+  querySchema: {
+    type: 'object',
+    properties: {
+      pageIndex: { type: 'integer', default: DEFAULT_PAGE_INDEX },
+      pageSize: { type: 'integer', default: DEFAULT_PAGE_SIZE },
+      state: { type: 'string', enum: STATES },
+      scope: {
+        type: 'string',
+        enum: SCOPES,
+        title: t('DeviceDataCapability.query.scope'),
+      },
+    },
+  },
+  outputSchema: arrayOutputSchema,
+  create: () => ({
+    query<T = unknown>(request: DataSourceRequest, context: RuntimeContext) {
+      return defer(() => loadDeviceDetailPage(
+        toDetailPageQuery(request),
+        request.signal || context.signal,
+      )).pipe(map(page => toPageResult<T>(page)))
+    },
+  }),
+}
+
 function toStateBatchQuery(request: DataSourceRequest): DeviceStateBatchQuery {
   const deviceIds = uniqueTexts(request.query?.deviceIds)
   if (!deviceIds.length || deviceIds.length > MAX_DEVICE_IDS) {
@@ -103,6 +151,42 @@ function toDetailQuery(request: DataSourceRequest): DeviceDetailQuery {
     throw new Error(t('DeviceInstanceDataCapability.error.invalidDeviceId'))
   }
   return { deviceId }
+}
+
+function toDetailPageQuery(request: DataSourceRequest): DeviceDetailPageQuery {
+  const state = optionalText(request.query?.state)
+  if (state && !STATES.includes(state as DeviceMonitoringState)) {
+    throw new Error(t('DeviceDataCapability.error.invalidState'))
+  }
+  const scope = optionalText(request.query?.scope)
+  if (scope && !SCOPES.includes(scope as DeviceMonitoringScope)) {
+    throw new Error(t('DeviceDataCapability.error.invalidScope'))
+  }
+  return {
+    pageIndex: integerInRange(
+      request.query?.pageIndex,
+      DEFAULT_PAGE_INDEX,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
+    pageSize: integerInRange(
+      request.query?.pageSize ?? request.limit,
+      DEFAULT_PAGE_SIZE,
+      1,
+      MAX_PAGE_SIZE,
+    ),
+    state: state as DeviceMonitoringState | undefined,
+    scope: scope as DeviceMonitoringScope | undefined,
+  }
+}
+
+function toPageResult<T>(page: DeviceDetailPageData): DataSourceResult<T> {
+  return {
+    data: page.data as T,
+    total: page.total,
+    pageIndex: page.pageIndex,
+    pageSize: page.pageSize,
+  }
 }
 
 function uniqueTexts(value: unknown): string[] {
@@ -120,12 +204,26 @@ function optionalText(value: unknown): string | undefined {
   return valueText || undefined
 }
 
+function integerInRange(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (value === undefined || value === null || value === '') return fallback
+  const number = Number(value)
+  if (!Number.isInteger(number) || number < min || number > max) {
+    throw new Error(t('DeviceDataCapability.error.invalidPagination'))
+  }
+  return number
+}
+
 const deviceInstanceMonitoringProvider: DataCapabilityProvider = {
   id: PROVIDER_ID,
   owner,
-  capabilityIds: [STATE_BATCH_SOURCE_ID, DETAIL_SOURCE_ID],
+  capabilityIds: [STATE_BATCH_SOURCE_ID, DETAIL_SOURCE_ID, DETAIL_PAGE_SOURCE_ID],
   load: () => ({
-    sources: [stateBatchSource, detailSource],
+    sources: [stateBatchSource, detailSource, detailPageSource],
   }),
 }
 

--- a/dataCapabilities/deviceMonitoring.service.ts
+++ b/dataCapabilities/deviceMonitoring.service.ts
@@ -83,9 +83,11 @@ export async function loadDeviceLocationList(
   query: DeviceLocationQuery,
   signal?: AbortSignal,
 ): Promise<DeviceLocationPageData> {
-  const terms = query.state
-    ? [{ column: 'state', termType: 'eq', value: query.state }]
-    : []
+  const terms: UnknownRecord[] = []
+  if (query.scope === 'iot') terms.push(createIotDeviceScopeTerm())
+  if (query.state) {
+    terms.push({ column: 'state', termType: 'eq', value: query.state })
+  }
   const response = await getDeviceGeoJson({
     paging: true,
     pageIndex: query.pageIndex,
@@ -155,9 +157,7 @@ export async function loadDeviceRuntimeTrend(
     const group = text(row.group)
     if (group !== ONLINE_RATE_GROUP && group !== MESSAGE_COUNT_GROUP) return
     const data = asRecord(row.data)
-    const timestamp = toTimestamp(
-      data.timestamp ?? data.timeString ?? row.timestamp ?? row.timeString,
-    )
+    const timestamp = toTimestamp(data.timeString)
     if (timestamp === null) return
 
     const point = points.get(timestamp) || {

--- a/dataCapabilities/deviceMonitoring.types.ts
+++ b/dataCapabilities/deviceMonitoring.types.ts
@@ -23,6 +23,7 @@ export interface DeviceLocationQuery {
   pageIndex: number
   pageSize: number
   state?: DeviceMonitoringState
+  scope?: DeviceMonitoringScope
 }
 
 export interface DeviceLocationRow {

--- a/dataCapabilities/deviceMonitoringProvider.ts
+++ b/dataCapabilities/deviceMonitoringProvider.ts
@@ -97,6 +97,11 @@ const locationSource: DataSourceDefinition = {
       pageIndex: { type: 'integer', default: DEFAULT_PAGE_INDEX },
       pageSize: { type: 'integer', default: DEFAULT_PAGE_SIZE },
       state: { type: 'string', enum: STATES },
+      scope: {
+        type: 'string',
+        enum: SCOPES,
+        title: t('DeviceDataCapability.query.scope'),
+      },
     },
   },
   outputSchema: arrayOutputSchema,
@@ -181,6 +186,7 @@ function toLocationQuery(request: DataSourceRequest): DeviceLocationQuery {
     pageIndex: integerInRange(request.query?.pageIndex, DEFAULT_PAGE_INDEX, 0),
     pageSize: integerInRange(request.query?.pageSize ?? request.limit, DEFAULT_PAGE_SIZE, 1, MAX_PAGE_SIZE),
     state: state as DeviceMonitoringState | undefined,
+    scope: toScope(request.query?.scope),
   }
 }
 

--- a/docs/设备运行数据能力接口说明.md
+++ b/docs/设备运行数据能力接口说明.md
@@ -2,7 +2,7 @@
 
 ## 1. 能力边界
 
-`device-manager-ui` 通过 `moduleRegistry.register` 对外注册 3 个只读 DataCapability Provider、共 9 个 DataSource，供可视化资源组件消费。
+`device-manager-ui` 通过 `moduleRegistry.register` 对外注册 3 个只读 DataCapability Provider、共 10 个 DataSource，供可视化资源组件消费。
 
 - owning module：`ui/modules/device-manager-ui`
 - moduleId：`device-manager-ui`
@@ -51,6 +51,7 @@
 | `device.category.distribution` | 设备类型分布 | `snapshot`、`poll` |
 | `device.state.batch` | 地图可视设备状态 | `snapshot` |
 | `device.detail` | 地图设备详情 | `snapshot` |
+| `device.detail.page` | 设备明细分页 | `page`、`snapshot` |
 | `device.group.list` | 设备业务分组 | `snapshot` |
 | `device.group.summary.batch` | 分组状态汇总 | `snapshot` |
 | `device.group.devices.page` | 分组设备明细 | `page`、`snapshot` |
@@ -99,6 +100,7 @@
 
 ```json
 {
+  "scope": "iot",
   "pageIndex": 0,
   "pageSize": 200,
   "state": "online"
@@ -108,6 +110,7 @@
 - `pageIndex` 默认 `0`。
 - `pageSize` 默认 `200`，最大 `1000`。
 - `state` 可选值为 `online`、`offline`、`notActive`。
+- `scope=iot` 时，Provider 统一加入物联设备范围条件。
 - 坐标缺失的数据不进入位置列表。
 
 ### 4.3 设备运行趋势 `device.runtime.trend`
@@ -176,6 +179,10 @@
 - `transportProtocol`、`transport`、`accessProvider` 按顺序映射为 `accessMode`。
 - `description`、`describe` 映射为 `description`。
 - 在线设备的 `lastActiveTime` 取 `onlineTime`，离线设备取 `offlineTime`；其他状态返回 `null`。
+
+### 5.3 设备明细分页 `device.detail.page`
+
+请求参数为 `scope`、`state`、`pageIndex`、`pageSize`；`scope=iot` 时由 Provider 统一加入物联设备范围，调用方不传递后端 `terms`。返回设备标识、名称、产品、状态、区域和最近活动时间，并携带统一分页信息。
 
 ## 6. 设备分组能力
 

--- a/locales/lang/en.json
+++ b/locales/lang/en.json
@@ -4224,6 +4224,8 @@
     "DeviceInstanceDataCapability.state.description": "Query runtime states for a batch of devices.",
     "DeviceInstanceDataCapability.detail.name": "Device Details",
     "DeviceInstanceDataCapability.detail.description": "Query basic information and the latest active time for a device.",
+    "DeviceInstanceDataCapability.detailPage.name": "Device Detail Page",
+    "DeviceInstanceDataCapability.detailPage.description": "Page through device details and runtime states.",
     "DeviceInstanceDataCapability.query.deviceIds": "Device IDs",
     "DeviceInstanceDataCapability.query.deviceId": "Device ID",
     "DeviceInstanceDataCapability.error.invalidDeviceIds": "Invalid device ID list; at most 200 devices can be queried at once",

--- a/locales/lang/zh.json
+++ b/locales/lang/zh.json
@@ -4225,6 +4225,8 @@
     "DeviceInstanceDataCapability.state.description": "批量查询指定设备的运行状态。",
     "DeviceInstanceDataCapability.detail.name": "设备详情",
     "DeviceInstanceDataCapability.detail.description": "查询指定设备的基础信息与最近活动时间。",
+    "DeviceInstanceDataCapability.detailPage.name": "设备明细分页",
+    "DeviceInstanceDataCapability.detailPage.description": "分页查询物联设备明细及运行状态。",
     "DeviceInstanceDataCapability.query.deviceIds": "设备ID列表",
     "DeviceInstanceDataCapability.query.deviceId": "设备ID",
     "DeviceInstanceDataCapability.error.invalidDeviceIds": "设备ID列表不正确，单次最多查询200个设备",

--- a/register.ts
+++ b/register.ts
@@ -53,6 +53,7 @@ export default {
       capabilityIds: [
         'device.state.batch',
         'device.detail',
+        'device.detail.page',
       ],
       loader: () => import('./dataCapabilities/deviceInstanceMonitoringProvider'),
     },


### PR DESCRIPTION
## 目的

- 扩展设备运行数据能力，提供设备明细分页查询。
- 支持物联设备范围筛选并统一设备数据输出。

## 核心变动

- 设备实例监控：新增 `device.detail.page` 数据源、分页参数校验与结果标准化。
- 设备监控：位置列表支持 `scope=iot`，调整运行趋势时间字段解析。
- 模块注册与文档：注册新增能力，补充中英文文案和接口说明。

## 设计与测试目标

- 设计稿：不适用，本次为现有前端数据能力扩展。
- 用户确认：已确认创建正式 PR。
- 测试目标：未执行；遵循用户要求，本次不运行编译、自动化测试或截图测试。
- 注释 / 公共契约：不适用；未涉及后端公共类或 SPI。
- 数据权限：不适用；本次仅调整前端只读 DataCapability 查询能力。
- 数据库兼容与性能：不适用；未修改数据库或 SQL。
- 链路追踪：不适用；未修改后端链路。
- MBean 运维可观测性：不适用；未涉及后台任务、缓存或队列。

## 测试结果

- 命令：未执行（0 条），遵循用户要求不运行项目编译或测试。
- 新增/更新测试：无。
- 单元测试：未执行，未产生 passed / failed / skipped 数据。
- 集成测试：不适用；本次为前端模块数据能力扩展，未修改数据库、消息、事件、协议、跨模块后端边界、外部依赖或启动装配。
- 压力测试：不适用；前端仅透传分页参数，未修改 SQL 或批量写入。
- 覆盖率：未采集；未执行测试或覆盖率命令。

## 文档同步情况

- 已同步：`docs/设备运行数据能力接口说明.md`、中英文国际化资源。
- 未同步：无。
- 说明：README 长期总览无需调整；测试证据保留在 PR 描述中，未新增任务流水文档。

## 风险与说明

- 影响范围：`device-manager-ui` 的设备实例监控、设备监控 DataCapability 及模块注册。
- 注释 / 公共契约：不涉及后端公共契约。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未执行编译、类型检查、自动化测试或页面验证。
- 已知限制：PR 进入评审前需由项目侧完成必要验证。
