### PR TITLE
refactor(设备管理): 复用设备详情查询

### DIFF
--- a/api/instance.ts
+++ b/api/instance.ts
@@ -42,10 +42,11 @@ export const detail = (id: string, hiddenError?: any) => request.get<DeviceInsta
 export const query = (data?: Record<string, any>) => request.post('/device-instance/_query', data)
 
 /**
- * 查询设备并返回所属产品的当前语言名称。
+ * 分页查询设备详情
+ * @param data 分页搜索数据
+ * @returns
  */
-export const queryWithProductI18n = (data?: Record<string, any>) =>
-  request.post('/device-instance/i18n/_query', data)
+export const queryDetails = (data?: Record<string, any>) => request.post('/device-instance/detail/_query', data)
 
 /**
  * 不分页查询设备

--- a/views/device/Instance/index.vue
+++ b/views/device/Instance/index.vue
@@ -9,9 +9,16 @@
             <JProTable
                 ref="instanceRef"
                 :columns="columns"
-                :request="queryWithProductI18n"
+                :request="queryDetails"
                 :defaultParams="{
                     sorts: [{ name: 'createTime', order: 'desc' }, { name: 'name', order: 'desc'}],
+                    context: {
+                        includeTags: false,
+                        includeBind: false,
+                        includeRelations: false,
+                        includeFirmwareInfos: false,
+                        includeParent: false,
+                    },
                 }"
                 :rowSelection="
                     isCheck
@@ -67,7 +74,8 @@
                             <Image
                                 class="card-list-img-80"
                                 :src="
-                                    slotProps?.photoUrl ||
+                                    slotProps?.devicePhotoUrl ||
+                                    slotProps?.productPhotoUrl ||
                                     device.deviceCard
                                 "
                             />
@@ -136,8 +144,8 @@
                 <template #name="slotProps">
                     {{ getI18nText(slotProps, 'name') }}
                 </template>
-                <template #describe="slotProps">
-                    {{ getI18nText(slotProps, 'describe') }}
+                <template #description="slotProps">
+                    {{ getI18nText(slotProps, 'description') }}
                 </template>
                 <template #productName="slotProps">
                     {{ getI18nText(slotProps, 'productName') }}
@@ -212,7 +220,7 @@
 
 <script setup lang="ts">
 import {
-    queryWithProductI18n,
+    queryDetails,
     _delete,
     _deploy,
     _undeploy,
@@ -459,11 +467,12 @@ const columns = ref([
     },
     {
         title: $t('Instance.index.133466-18'),
-        dataIndex: 'describe',
-        key: 'describe',
+        dataIndex: 'description',
+        key: 'description',
         ellipsis: true,
         search: {
             type: 'string',
+            rename: 'describe',
         },
     },
     {

--- a/views/device/Instance/typings.d.ts
+++ b/views/device/Instance/typings.d.ts
@@ -9,7 +9,6 @@ export type DeviceInstance = {
   description: string;
   productId: string;
   productName: string;
-  i18nProductName?: string;
   protocolName: string;
   security: any;
   deriveMetadata: string;


### PR DESCRIPTION
## 目的

- 收敛设备列表国际化查询，复用通用设备详情分页接口。
- 移除仅为产品名称国际化设置的专用查询接口依赖。

## 核心变动

- `device-manager-ui`：设备列表改用 `/device-instance/detail/_query`。
- `device-manager-ui`：复用既有 `includeTags` 等查询上下文关闭无关关联数据。
- `device-manager-ui`：适配详情响应中的描述和设备 / 产品图片字段，移除旧接口类型字段。

## 设计与测试目标

- 设计稿：不适用，复用既有设备详情查询契约。
- 用户确认：已确认。
- 测试目标：设备列表按当前语言展示设备与产品字段，且不再请求专用国际化接口。
- 注释 / 公共契约：不适用，未新增公共契约。
- 数据权限：不适用，沿用设备详情查询接口既有权限处理。
- 数据库兼容与性能：不适用，未调整数据库访问。
- 链路追踪：不适用，未涉及后端链路。
- MBean 运维可观测性：不适用，未涉及常驻资源。

## 测试结果

- 静态检查：`git diff --check origin/2.12...HEAD` 通过。
- 前端构建：未完成；当前 Vite 构建入口未注册 `--module-name` 参数，执行模块定向构建会报 `Unknown option --moduleName`。
- 集成测试：不适用，未涉及后端、消息、协议或跨服务边界。
- 覆盖率：前端模块未配置本次变更的覆盖率采集。

## 文档同步情况

- 已同步：无，未改变模块长期职责或接口。
- 未同步：无。
- 说明：测试证据保留在 PR / CI，未新增临时文档。

## 风险与说明

- 影响范围：运行时设备列表查询和展示。
- 注释 / 公共契约：不涉及。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：浏览器内中英文列表展示与筛选回归尚待人工验证。
- 已知限制：依赖后端 PR #428 提供的设备详情国际化字段。