### PR TITLE
fix: 修复设备详情属性数据刷新异常

### DIFF
--- a/DEVICE_DETAIL_HANDOFF.md
+++ b/DEVICE_DETAIL_HANDOFF.md
@@ -74,6 +74,18 @@
   - `查看详情` 已升级为带时间过滤、列表、图表的详情弹层
   - 目前图表与历史数据仍以 `iot-ui` 本地轻量数据生成逻辑为主，尚未切到旧版真实属性接口链
 
+- [IotDeviceDataTableTab.vue](views/device/list/components/device-detail/IotDeviceDataTableTab.vue)
+  - 当前修复目标：设备数据页属性卡片在接收实时上报后，按属性标识映射到最新 `props.properties`，避免 `j-pro-table` CARD 模式沿用 request 返回的旧对象导致界面不刷新。
+  - 影响范围与 owning module：仅 `ui/modules/device-manager-ui` 设备详情前端；不改 WebSocket topic、后端接口、数据详情弹层查询或主动快照查询策略。
+  - 验证方式：运行 `pnpm -F jetlinks-web-core build -- --module-name device-manager-ui`，并在页面复测设备属性上报后当前页卡片值、更新时间和详情入口属性对象是否随之更新。
+  - 验证结果：`pnpm -F jetlinks-web-core build -- --module-name device-manager-ui` 通过；构建输出仍包含既有 CSS `//background` 注释与大 chunk 警告。
+
+- [IotDevicePropertyDetailModal.vue](views/device/list/components/device-detail/IotDevicePropertyDetailModal.vue)
+  - 当前修复目标：属性详情弹层每次打开或切换属性 / 设备时，重新计算默认 `今天` 时间范围，避免关闭后再次打开沿用上一次固定的结束时间。
+  - 影响范围与 owning module：仅 `ui/modules/device-manager-ui` 设备详情前端；不改属性卡片实时值刷新、历史数据接口、图表组件或后端查询参数契约。
+  - 验证方式：运行 `pnpm -F jetlinks-web-core build -- --module-name device-manager-ui`，并在页面复测关闭后重新打开属性详情时结束时间是否更新为当前时间。
+  - 验证结果：`pnpm -F jetlinks-web-core build -- --module-name device-manager-ui` 通过；构建输出仍包含既有 CSS `//background` 注释与大 chunk 警告。
+
 - [IotDeviceEventGroupsTab.vue](views/device/list/components/device-detail/IotDeviceEventGroupsTab.vue)
   - 事件按分组展示的轻量实现
   - 目前是按 `RealtimeEventRow.id` 做分组分页骨架

--- a/views/device/list/components/device-detail/IotDeviceDataTableTab.vue
+++ b/views/device/list/components/device-detail/IotDeviceDataTableTab.vue
@@ -2,21 +2,21 @@
   <section class="device-data-tab">
     <IotDevicePropertyReadModal
       v-model:open="readOpen"
-      :property="selectedProperty"
+      :property="selectedLiveProperty"
       :tone="selectedTone"
       :loading="reading"
       @confirm="readSelectedProperty"
     />
     <IotDevicePropertyWriteModal
       v-model:open="writeOpen"
-      :property="selectedProperty"
+      :property="selectedLiveProperty"
       :loading="writing"
       @confirm="writeSelectedProperty"
     />
     <IotDevicePropertyDetailModal
       v-model:open="detailOpen"
       :device-id="deviceId"
-      :property="selectedProperty"
+      :property="selectedLiveProperty"
       :tone="selectedTone"
     />
     <header class="data-toolbar">
@@ -87,26 +87,26 @@
         <template #card="item">
           <article
             class="data-property-card"
-            :data-tone="cardTone(item, propertyCardIndex(item))"
+            :data-tone="cardTone(liveProperty(item), propertyCardIndex(liveProperty(item)))"
           >
             <header>
               <div class="property-title">
                 <span />
-                <strong>{{ item.name }}</strong>
+                <strong>{{ liveProperty(item).name }}</strong>
               </div>
               <div class="property-actions">
-                <a-tooltip v-if="canReadProperty(item)" :title="$t('IotDeviceDetail.dataTable.readProperty')">
-                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.readProperty')" @click="openRead(item)">
+                <a-tooltip v-if="canReadProperty(liveProperty(item))" :title="$t('IotDeviceDetail.dataTable.readProperty')">
+                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.readProperty')" @click="openRead(liveProperty(item))">
                     <template #icon><AIcon type="ReloadOutlined" /></template>
                   </a-button>
                 </a-tooltip>
-                <a-tooltip v-if="canWriteProperty(item)" :title="$t('IotDeviceDetail.dataTable.writeProperty')">
-                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.writeProperty')" @click="openWrite(item)">
+                <a-tooltip v-if="canWriteProperty(liveProperty(item))" :title="$t('IotDeviceDetail.dataTable.writeProperty')">
+                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.writeProperty')" @click="openWrite(liveProperty(item))">
                     <template #icon><AIcon type="EditOutlined" /></template>
                   </a-button>
                 </a-tooltip>
                 <a-tooltip :title="$t('IotDeviceDetail.dataTable.detail')">
-                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.detail')" @click="openDetail(item)">
+                  <a-button type="text" size="small" :aria-label="$t('IotDeviceDetail.dataTable.detail')" @click="openDetail(liveProperty(item))">
                     <template #icon><AIcon type="LineChartOutlined" /></template>
                   </a-button>
                 </a-tooltip>
@@ -114,23 +114,23 @@
             </header>
             <div class="property-value">
               <IotDevicePropertyValuePreview
-                :value="item.value"
-                :value-type="item.valueType"
-                :data-type="item.dataType"
-                :name="item.name"
+                :value="liveProperty(item).value"
+                :value-type="liveProperty(item).valueType"
+                :data-type="liveProperty(item).dataType"
+                :name="liveProperty(item).name"
               />
-              <span v-if="propertyDisplayUnit(item)">{{ propertyDisplayUnit(item) }}</span>
+              <span v-if="propertyDisplayUnit(liveProperty(item))">{{ propertyDisplayUnit(liveProperty(item)) }}</span>
             </div>
             <IotDevicePropertySparkline
-              :property="item"
-              :rows="getSparklineRows(item)"
-              :tone="cardTone(item, propertyCardIndex(item))"
+              :property="liveProperty(item)"
+              :rows="getSparklineRows(liveProperty(item))"
+              :tone="cardTone(liveProperty(item), propertyCardIndex(liveProperty(item)))"
               :time-range="propertyTimeRange"
             />
             <footer>
-              <span>{{ propertyStatusText(item, propertyCardIndex(item)) }}</span>
+              <span>{{ propertyStatusText(liveProperty(item), propertyCardIndex(liveProperty(item))) }}</span>
               <i />
-              <span>{{ propertyTimeText(item, propertyCardIndex(item)) }}</span>
+              <span>{{ propertyTimeText(liveProperty(item), propertyCardIndex(liveProperty(item))) }}</span>
             </footer>
           </article>
         </template>
@@ -252,7 +252,11 @@ const {
   deviceId: () => props.deviceId,
   onValue: (value) => emit('property-value', value),
 })
-const selectedTone = computed(() => selectedProperty.value ? cardTone(selectedProperty.value, props.properties.indexOf(selectedProperty.value)) : 'primary')
+const propertyByIdentifier = computed(() => new Map(
+  props.properties.map((item) => [item.identifier.toLowerCase(), item]),
+))
+const selectedLiveProperty = computed(() => selectedProperty.value ? liveProperty(selectedProperty.value) : null)
+const selectedTone = computed(() => selectedLiveProperty.value ? cardTone(selectedLiveProperty.value, propertyCardIndex(selectedLiveProperty.value)) : 'primary')
 const {
   propertyPaginationOptions,
   filteredPropertyCards,
@@ -315,6 +319,10 @@ function cardTone(item: RealtimePropertyRow, index: number) {
   if (item.tone === 'critical') return 'danger'
   if (item.tone === 'warning') return 'warning'
   return ['primary', 'cyan', 'success', 'warning', 'slate', 'slate', 'primary'][index % 7]
+}
+
+function liveProperty(item: RealtimePropertyRow) {
+  return propertyByIdentifier.value.get(item.identifier.toLowerCase()) ?? item
 }
 
 function propertyStatusText(item: RealtimePropertyRow, index: number) {

--- a/views/device/list/components/device-detail/IotDevicePropertyDetailModal.vue
+++ b/views/device/list/components/device-detail/IotDevicePropertyDetailModal.vue
@@ -327,17 +327,36 @@ function openRowDetail(row: DetailRow) {
   rowDetailOpen.value = true
 }
 
+function resetDetailStateForOpen() {
+  const nextRange = getShortcutRange('today')
+  const rangeChanged = detailTimeRange.value[0]?.valueOf() !== nextRange[0].valueOf()
+    || detailTimeRange.value[1]?.valueOf() !== nextRange[1].valueOf()
+
+  // 弹层关闭后组件状态会保留，重新打开时需要刷新快捷时间段的结束时间。
+  detailRange.value = 'today'
+  detailTimeRange.value = nextRange
+  detailRows.value = []
+  pageTotal.value = 0
+  pageCurrent.value = 1
+  rowDetailOpen.value = false
+  selectedDetailRow.value = null
+  resetHistoryFilter()
+  if (!isGeoPointProperty.value && detailMode.value === 'trajectory') {
+    detailMode.value = 'list'
+  }
+
+  return rangeChanged
+}
+
 watch(
-  () => [props.open, props.deviceId, props.property?.identifier, detailMode.value, detailTimeRange.value?.[0]?.valueOf(), detailTimeRange.value?.[1]?.valueOf()],
-  (_next, prev) => {
-    const propertyChanged = prev?.[2] !== props.property?.identifier
-    if (propertyChanged) {
-      detailRows.value = []
-      pageTotal.value = 0
-      resetHistoryFilter()
-      if (!isGeoPointProperty.value && detailMode.value === 'trajectory') {
-        detailMode.value = 'list'
-      }
+  () => [props.open, props.deviceId, props.property?.identifier, detailMode.value, detailTimeRange.value?.[0]?.valueOf(), detailTimeRange.value?.[1]?.valueOf()] as const,
+  ([open, deviceId, propertyId], prev) => {
+    const opened = open && !prev?.[0]
+    const deviceChanged = prev?.[1] !== deviceId
+    const propertyChanged = prev?.[2] !== propertyId
+
+    if (open && propertyId && (opened || deviceChanged || propertyChanged)) {
+      if (resetDetailStateForOpen()) return
     }
     pageCurrent.value = 1
     void loadRows()

--- a/views/device/list/components/device-detail/useIotDevicePropertyPagination.ts
+++ b/views/device/list/components/device-detail/useIotDevicePropertyPagination.ts
@@ -11,6 +11,7 @@ export function useIotDevicePropertyPagination(
   propertyGroup: Ref<string>,
 ) {
   let firstRequest = true
+  const lastPageParams = ref({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE })
   const visiblePropertyCards = ref<RealtimePropertyRow[]>([])
   const filteredPropertyCards = computed(() => properties.value.filter((item) => {
     const matchesGroup = propertyGroup.value === '__all__' || item.groupId === propertyGroup.value
@@ -52,13 +53,22 @@ export function useIotDevicePropertyPagination(
     showLessItems: true,
   }
 
-  const requestPropertyCards = async (params: Record<string, unknown>) => {
+  function getPageRows(params = lastPageParams.value) {
     const pageIndex = Number(params.pageIndex ?? 0)
     const requestedPageSize = Number(params.pageSize ?? DEFAULT_PAGE_SIZE)
     const pageSize = firstRequest && requestedPageSize === 12 ? DEFAULT_PAGE_SIZE : requestedPageSize
     const start = pageIndex * pageSize
-    const data = filteredPropertyCards.value.slice(start, start + pageSize)
+    return {
+      data: filteredPropertyCards.value.slice(start, start + pageSize),
+      pageIndex,
+      pageSize,
+    }
+  }
+
+  const requestPropertyCards = async (params: Record<string, unknown>) => {
+    const { data, pageIndex, pageSize } = getPageRows(params)
     firstRequest = false
+    lastPageParams.value = { pageIndex, pageSize }
     visiblePropertyCards.value = data
 
     return {
@@ -71,6 +81,14 @@ export function useIotDevicePropertyPagination(
       },
     }
   }
+
+  watch(
+    filteredPropertyCards,
+    () => {
+      // CARD 模式会保留 request 返回的当前页数据；实时值变更时只替换当前页切片，避免跳回第一页。
+      visiblePropertyCards.value = getPageRows().data
+    },
+  )
 
   function propertyCardIndex(item: RealtimePropertyRow) {
     const index = filteredPropertyCards.value.findIndex((property) => property.id === item.id)


### PR DESCRIPTION
## 目的

- 修复设备详情「数据 -> 属性」页在设备属性上报后，当前页属性卡片不实时刷新的问题
- 修复属性详情弹层关闭后重新打开时，默认时间范围结束时间沿用旧值的问题

## 核心变动

- 设备数据页：属性卡片、读取 / 设置 / 详情入口按属性标识映射到最新 `props.properties`
- 分页 hook：`j-pro-table` CARD 模式下实时值变化时同步当前页切片，避免界面沿用 request 返回的旧对象，同时不跳回第一页
- 属性详情弹层：每次打开或切换设备 / 属性时重新计算默认 `今天` 时间范围
- 文档：同步更新 `DEVICE_DETAIL_HANDOFF.md` 中的修复目标、影响范围和验证结果

## 设计与测试目标

- 设计稿：不适用，前端窄范围缺陷修复，未改变页面信息架构、接口契约或后端行为
- 用户确认：已确认，用户要求提交 PR
- 测试目标：覆盖设备属性上报后当前页属性卡片刷新、详情入口属性对象更新、详情弹层重新打开默认结束时间重新计算；真实设备上报浏览器联调需在测试环境继续复测
- 注释 / 公共契约：适用；已在 CARD 当前页切片同步和详情弹层打开状态重置处补充状态联动注释
- 数据权限：不适用，纯前端展示状态修复，不改查询权限、详情权限或资产权限
- 数据库兼容与性能：不适用，未涉及数据库、SQL、分页接口或聚合接口变更
- 链路追踪：不适用，未涉及后端链路、事件订阅或跨服务调用
- MBean 运维可观测性：不适用，未涉及常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`PATH=/Users/hukaiyu/.nvm/versions/node/v22.18.0/bin:$PATH pnpm -F jetlinks-web-core build -- --module-name device-manager-ui`
- 新增/更新测试：未新增自动化测试；本次为前端窄范围状态修复，已执行模块构建校验
- 单元测试：不适用，未涉及现有单测入口；模块构建结果为 8125 modules transformed, 0 build errors, exit code 0
- 集成测试：不适用，未改后端、数据库、消息、协议、跨模块边界、外部依赖或启动装配
- 压力测试：不适用，未涉及 SQL、聚合性能、批量写入或深分页
- 覆盖率：未生成覆盖率；本次执行 Vite 模块构建，项目未在该命令中输出 coverage，替代证据为 device-manager-ui 模块构建通过

## 文档同步情况

- 已同步：`DEVICE_DETAIL_HANDOFF.md`
- 未同步：无
- 说明：README 无长期总览变化；测试证据放在 PR 描述中，未新增独立任务流水文档

## 风险与说明

- 影响范围：`ui/modules/device-manager-ui` 设备详情数据页属性卡片、属性详情弹层默认时间范围
- 注释 / 公共契约：已补复杂状态联动注释到代码中；不涉及公共 API、SPI 或跨模块契约
- 链路追踪 / 可观测性：不涉及后端链路追踪，未新增 TraceHolder / MonoTracer / FluxTracer
- MBean / 运维可观测性：不涉及后台任务或运维 MBean
- 未覆盖场景：未在真实设备上报环境完成浏览器联调，需在测试环境复测属性上报后当前页卡片值与更新时间实时变化
- 已知限制：构建输出仍包含既有 CSS `//background` 注释警告与大 chunk 警告，本次未处理
