### PR TITLE
refactor(设备管理): 统一设备页面图标与布局样式

### DIFF
--- a/views/device/alarm/index.vue
+++ b/views/device/alarm/index.vue
@@ -41,9 +41,12 @@
         >
           <template #name="record">
             <span class="device-alarm-page__name">
-              <span class="device-alarm-page__name-icon" aria-hidden="true">
-                <span class="device-alarm-page__name-initial">{{ alarmNameInitial(record) }}</span>
-              </span>
+              <IconBadge
+                :size="32"
+                :inner-size="24"
+                :text="alarmNameInitial(record)"
+                aria-hidden="true"
+              />
               <span class="device-alarm-page__name-text" :title="toAlarmRow(record).name">
                 {{ toAlarmRow(record).name || '--' }}
               </span>
@@ -130,6 +133,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import ConditionFilter from '@jetlinks-web-core/components/ConditionFilter'
+import IconBadge from '@jetlinks-web-core/components/IconBadge/index.vue'
 import { PageHeader } from '@jetlinks-web-core/components'
 import DeviceAlarmEditorModal from './components/DeviceAlarmEditorModal.vue'
 import DeviceAlarmRestoreButton from './components/DeviceAlarmRestoreButton.vue'
@@ -221,7 +225,6 @@ const notificationStatus = (record: Record<string, any>) => {
 	flex-direction: column;
   min-width: 0;
 	background: color-mix(in srgb, var(--jet-theme-bg-container) 70%, transparent);
-	padding: var(--space-4);
 	border-radius: var(--r-4);
 }
 .device-alarm-page__filter {
@@ -245,29 +248,6 @@ const notificationStatus = (record: Record<string, any>) => {
   gap: var(--space-3);
   min-width: 0;
   max-width: 100%;
-}
-
-.device-alarm-page__name-icon {
-  position: relative;
-  display: inline-grid;
-  flex: 0 0 2rem;
-  place-items: center;
-  width: 2rem;
-  height: 2rem;
-  overflow: hidden;
-  color: #6b9cff;
-  font-size: 20px;
-  background: linear-gradient(180deg, var(--jet-theme-primary) 0%, var(--accent-soft) 100%);
-  border: 1px solid #f3f7fc;
-  border-radius: 50%;
-}
-
-.device-alarm-page__name-initial {
-  position: absolute;
-  color: #fff;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 22px;
 }
 
 .device-alarm-page__name-text {

--- a/views/device/health/components/IotDeviceHealthView.vue
+++ b/views/device/health/components/IotDeviceHealthView.vue
@@ -87,7 +87,7 @@ const {
 
 <style scoped>
 .iot-health {
-  --iot-health-layout-offset: 8.75rem;
+  --iot-health-layout-offset: 10.75rem;
   display: grid;
   min-width: 0;
 }

--- a/views/device/health/components/IotHealthDetailPanel.vue
+++ b/views/device/health/components/IotHealthDetailPanel.vue
@@ -131,7 +131,6 @@ const { t: $t } = useI18n()
   min-height: 0;
   min-width: 0;
   overflow: auto;
-  background: var(--jet-theme-bg-layout);
   container-type: inline-size;
 }
 

--- a/views/device/health/components/IotHealthTree.vue
+++ b/views/device/health/components/IotHealthTree.vue
@@ -230,72 +230,7 @@ function handleKeywordSearch(value: string) {
   padding: 0 1rem 1rem;
 }
 
-.iot-health-tree__body :deep(.ant-tree) {
-  background: transparent;
-}
-
-.iot-health-tree__body :deep(.ant-tree-indent-unit) {
-  width: 1rem;
-}
-
-.iot-health-tree__body :deep(.ant-tree-treenode) {
-  align-items: center;
-  min-height: 2.25rem;
-  padding: 0;
-}
-
-.iot-health-tree__body :deep(.ant-tree-switcher) {
-  width: 1rem;
-  height: 2.25rem;
-  color: var(--jet-theme-text-disabled);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.iot-health-tree__body :deep(.ant-tree-node-content-wrapper) {
-  position: relative;
-  display: flex;
-  flex: 1;
-  align-items: center;
-  min-width: 0;
-  min-height: 2.25rem;
-  padding: 0 var(--space-2);
-  border-radius: 0.5rem;
-}
-
-.iot-health-tree__body :deep(.ant-tree-node-content-wrapper.ant-tree-node-selected) {
-	border-left: 2px solid var(--jet-theme-primary);
-  background: linear-gradient(90deg, var(--accent-soft) 0%, rgba(255, 255, 255, 0.10) 100%);
-}
-
-.iot-health-tree__body :deep(.ant-tree-node-content-wrapper.ant-tree-node-selected::before) {
-  position: absolute;
-  top: 0.375rem;
-  bottom: 0.375rem;
-  left: 0;
-  width: 0.125rem;
-  background: var(--accent-soft);
-  border-radius: 0 0.125rem 0.125rem 0;
-  content: '';
-}
-
-.iot-health-tree__body :deep(.ant-tree-node-content-wrapper.ant-tree-node-selected .iot-health-tree-title__name) {
-  color: var(--jet-theme-primary);
-  font-weight: var(--layout-menu-item-active-font-weight);
-}
-
-.iot-health-tree__body :deep(.ant-tree-title) {
-  display: block;
-  flex: 1;
-  min-width: 0;
-}
-
 .iot-health-tree__empty {
   padding: var(--space-6) 0;
-}
-
-:deep(.ant-tree-switcher-noop) {
-  display: none !important;
 }
 </style>

--- a/views/device/list/components/IotDeviceAssetTable.vue
+++ b/views/device/list/components/IotDeviceAssetTable.vue
@@ -94,20 +94,13 @@
 
       <template #device="record">
         <div class="iot-device-list__device-cell" @click="onDetail(record.id)">
-          <span
-            class="iot-device-list__device-icon"
-            :data-tone="connectionStatusOf(record).tone"
-            :data-image="hasVisibleImage(record)"
-          >
-            <img
-              v-if="hasVisibleImage(record)"
-              :src="record.imageUrl"
-              :alt="$t('IotDeviceList.table.deviceImageAlt', { name: record.name })"
-              loading="lazy"
-              @error="markImageFailed(record.id)"
-            >
-            <AIcon v-else :type="deviceIconType(record)" />
-          </span>
+          <IconBadge
+            :image="record.imageUrl"
+            :icon="deviceIconType(record)"
+            :size="40"
+            :inner-size="32"
+            :alt="$t('IotDeviceList.table.deviceImageAlt', { name: record.name })"
+          />
           <div class="iot-device-list__device-body">
             <div class="iot-device-list__device-name">
               <a-tooltip :title="displayText(record.name)">
@@ -235,6 +228,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import IconBadge from '@jetlinks-web-core/components/IconBadge/index.vue'
 
 import IotDeviceAssetActionPanel from './IotDeviceAssetActionPanel.vue'
 import { useIotDeviceAssetTableColumns } from './useIotDeviceAssetTableColumns'
@@ -273,7 +267,6 @@ const props = defineProps<{
 }>()
 const actionPopoverOpenId = ref('')
 const columns = useIotDeviceAssetTableColumns($t)
-const failedImageIds = ref(new Set<string>())
 const resultSummaryText = computed(() =>
   props.hasActiveFilters
     ? $t('IotDeviceList.toolbar.filteredSummary', { total: props.totalDevices })
@@ -302,14 +295,6 @@ function deviceIconType(device: IotDevice) {
   if (device.deviceTypeValue === 'gateway') return 'GatewayOutlined'
   if (device.deviceTypeValue === 'childrenDevice') return 'ApartmentOutlined'
   return 'ApiOutlined'
-}
-
-function hasVisibleImage(device: IotDevice) {
-  return Boolean(device.imageUrl && !failedImageIds.value.has(device.id))
-}
-
-function markImageFailed(deviceId: string) {
-  failedImageIds.value = new Set([...failedImageIds.value, deviceId])
 }
 
 function displayText(value?: string) {

--- a/views/device/list/styles/device-list-table.less
+++ b/views/device/list/styles/device-list-table.less
@@ -76,48 +76,6 @@
   cursor: pointer;
 }
 
-.iot-device-list__device-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: var(--jet-theme-stroke-width) solid var(--jet-theme-border-secondary);
-  border-radius: var(--r-pill);
-  font-size: var(--fs-16);
-  background: var(--jet-theme-primary-soft);
-  color: var(--info);
-  flex-shrink: 0;
-  overflow: hidden;
-}
-
-.iot-device-list__device-icon[data-tone='ok'] {
-  background: var(--ok-bg);
-  color: var(--ok);
-}
-
-.iot-device-list__device-icon[data-tone='err'] {
-  background: var(--err-bg);
-  color: var(--err);
-}
-
-.iot-device-list__device-icon[data-tone='muted'] {
-  background: var(--bg-hover);
-  color: var(--ink-2);
-}
-
-.iot-device-list__device-icon[data-image='true'] {
-  background: var(--bg);
-  color: inherit;
-}
-
-.iot-device-list__device-icon img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
 .iot-device-list__device-body {
   min-width: 0;
   display: grid;

--- a/views/scene-linkage/index.vue
+++ b/views/scene-linkage/index.vue
@@ -152,7 +152,6 @@ onMounted(reload)
 
 .scene-list-table {
 	background: var(--jet-theme-bg-container);
-	padding: var(--space-4);
 	border-radius: var(--jet-theme-radius);
 	display: grid;
 	gap: var(--space-4);


### PR DESCRIPTION
## 目的

- 统一设备告警、设备列表等页面的图标徽章和布局样式
- 复用 core 的 IconBadge，去除重复的页面级图标样式和图片失败状态逻辑

## 核心变动

- 设备告警：使用共享 IconBadge 替换页面内告警名称图标，并移除重复样式
- 设备健康：调整健康度布局高度偏移，移除详情面板和树组件的重复容器样式
- 设备列表：使用共享 IconBadge 处理设备图片、图标和图片加载失败回退，删除本地失败状态与图标样式
- 场景联动：移除重复的表格容器内边距

## 设计与测试目标

- 设计稿：不适用；本次为现有页面样式收敛，未改变业务流程或数据契约
- 用户确认：已确认；用户已要求提交 PR
- 测试目标：覆盖 Vue 模板、共享组件 props、模块装配与构建路径；定向模块构建通过
- 注释 / 公共契约：不适用；仅前端页面样式和共享组件调用，无新增公共契约
- 数据权限：不适用；未修改 API、权限或数据访问逻辑
- 数据库兼容与性能：不适用；未涉及数据库、SQL 或接口调用
- 链路追踪：不适用；未涉及关键后端业务链路
- MBean 运维可观测性：不适用；未涉及常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`pnpm --filter jetlinks-web-core build -- --module-name device-manager-ui`
- 新增/更新测试：无；本次为 Vue/Less 页面样式收敛，未引入可独立单测的业务逻辑
- 单元测试：不适用；本次未修改业务逻辑，已由定向 Vite 构建覆盖模板、TypeScript 和模块依赖解析
- 集成测试：不适用；未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配
- 压力测试：不适用；未涉及性能算法、接口或数据访问
- 覆盖率：不适用；本模块没有针对 Vue/Less 页面构建的覆盖率门槛；替代证据为 9,380 modules transformed、built in 2m 3s，退出码 0
- 补充验证：子模块原有 `pnpm build` 脚本引用不存在的 `jetlinks-ui-core` 过滤器，执行结果为未匹配项目；实际构建使用当前包名 `jetlinks-web-core`

## 文档同步情况

- 已同步：无长期文档需要更新；本次未改变模块职责、接口或使用方式
- 未同步：无
- 说明：未新增单次任务、测试报告或临时流水文档

## 风险与说明

- 影响范围：device-manager-ui 的设备告警、设备健康、设备列表和场景联动页面视觉样式
- 注释 / 公共契约：不涉及新增公共契约
- 链路追踪 / 可观测性：不涉及
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未执行带后端服务的浏览器 E2E；未涉及接口行为变更
- 已知限制：构建存在仓库既有资源路径、CSS 注释和大 chunk 警告；不影响本次构建退出码