### PR TITLE
fix(设备告警): 补充通知配置数据权限资产

### DIFF
--- a/baseMenu.json
+++ b/baseMenu.json
@@ -284,6 +284,11 @@
         },
         "supportDataAccess": true,
         "assetType": "device",
+        "assetTypes": [
+          "device",
+          "notifySubscriberProvider",
+          "notifyConfig"
+        ],
         "options": {
           "meta": {
             "componentCode": "device/alarm"


### PR DESCRIPTION
## 目的

- 修复设备告警菜单缺少通知订阅配置与通知配置数据权限资产声明的问题
- 让仅启用物联模块时，角色授权页也能为设备告警补充通知通道相关数据权限

## 核心变动

- device-manager-ui：在设备告警菜单保留 `device` 资产权限的基础上，补充 `notifySubscriberProvider` 与 `notifyConfig` 多资产声明

## 设计与测试目标

- 设计稿：不适用，本次为前端菜单权限元数据小修
- 用户确认：已确认
- 测试目标：验证 `baseMenu.json` 可正常解析，且改动范围仅限设备告警菜单数据权限资产声明
- 注释 / 公共契约：不适用，未修改代码逻辑或公共契约
- 数据权限：适用；设备告警菜单新增 `notifySubscriberProvider` 与 `notifyConfig` 资产类型声明，便于角色数据权限配置通知订阅配置与通知配置范围
- 数据库兼容与性能：不适用，未涉及数据库访问或 SQL
- 链路追踪：不适用，未涉及运行时链路
- MBean 运维可观测性：不适用，未涉及常驻任务、缓存、队列或后台执行器

## 测试结果

- 命令：`node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('ui/modules/device-manager-ui/baseMenu.json','utf8')); console.log('baseMenu json ok')"`
- 新增/更新测试：不适用，未修改运行时代码
- 单元测试：不适用，前端菜单 JSON 元数据调整未触发单元测试
- 集成测试：不适用，未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配
- 压力测试：不适用，未涉及性能路径
- 覆盖率：不适用，未修改可执行代码；替代验证为 JSON 解析通过，1 个文件解析成功，0 个解析失败

## 文档同步情况

- 已同步：不适用，改动为菜单数据权限元数据补充，不改变长期功能说明
- 未同步：无
- 说明：README 仅在长期总览需要变化时更新；测试证据放 PR / CI，未新增独立任务流水文档

## 风险与说明

- 影响范围：设备告警菜单的角色授权数据权限候选项
- 注释 / 公共契约：不涉及
- 链路追踪 / 可观测性：不涉及
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未通过页面人工验证角色授权页展示效果
- 已知限制：菜单初始化或授权数据刷新后，仍需给目标角色实际配置 `notifySubscriberProvider`、`notifyConfig` 数据权限，并重新登录或清理认证缓存后生效
