### PR TITLE
feat(设备管理): 支持复用设备接入详情

### DIFF
--- a/register.ts
+++ b/register.ts
@@ -29,6 +29,8 @@ export default {
   },
   components: {
     AccessCard: defineAsyncComponent(() => import('./views/link/AccessConfig/components/AccessCard/index.vue')),
+    // 跨模块对象详情复用同一设备接入实现，统一通过注册表公开，避免业务模块深层引用私有目录。
+    IotDeviceAccessDetailTab: defineAsyncComponent(() => import('./views/device/list/components/device-detail/IotDeviceAccessDetailTab.vue')),
     pluginPage: defineAsyncComponent(() => import('./views/link/plugin/Content.vue')),
     ProductPage: defineAsyncComponent(() => import('./views/device/Product/index.vue')),
     InstancePage: defineAsyncComponent(() => import('./views/device/Instance/index.vue')),

--- a/views/device/list/components/device-detail/IotDeviceAccessDetailTab.vue
+++ b/views/device/list/components/device-detail/IotDeviceAccessDetailTab.vue
@@ -90,6 +90,7 @@ const props = defineProps({
   commands: { type: Array as PropType<IotDeviceCommandDefinition[]>, required: true },
   sessionEnabled: { type: Boolean, default: true },
   traceEnabled: { type: Boolean, default: true },
+  defaultTab: { type: String as PropType<DeviceAccessInnerTab>, default: undefined },
 })
 
 const { t: $t } = useI18n()
@@ -109,14 +110,19 @@ const legacyChildrenRequested = computed(() =>
   route.query.tab === 'children'
   || ((route.query.tab === 'access' || route.query.tab === 'advanced') && route.query.sub === 'children'),
 )
+// 跨模块嵌入时没有设备详情路由参数，由调用方显式指定首次展示的内层页签。
 const accessConfigRequested = computed(() =>
-  route.query.tab === 'access' && (route.query.sub === 'connection' || route.query.sub === 'access'),
+  props.defaultTab === 'access'
+  || (route.query.tab === 'access' && (route.query.sub === 'connection' || route.query.sub === 'access')),
 )
 
 function getDefaultInnerTab(): DeviceAccessInnerTab {
   if (accessConfigRequested.value) return 'access'
   if (legacyChildrenRequested.value && isGatewayDevice.value) return 'children'
   if (legacyParsingRequested.value && hasTransparentCodec.value) return 'parsing'
+  if (props.defaultTab === 'children' && isGatewayDevice.value) return 'children'
+  if (props.defaultTab === 'parsing' && hasTransparentCodec.value) return 'parsing'
+  if (props.defaultTab === 'trace' && props.traceEnabled) return 'trace'
   if (!props.traceEnabled) return 'access'
   return isOnline.value ? 'trace' : 'access'
 }


### PR DESCRIPTION
## 变更说明

- 通过模块注册表公开设备接入详情组件，供边缘网关详情跨模块复用。
- 为设备接入详情增加默认内层页签参数，嵌入场景可直接展示接入配置。

## 验证

- `git diff --check origin/2.12-uat-next...HEAD`
- 本轮未重复执行前端构建；改动已在现有热部署页面联调流程中使用。

## 交付检查

- 后端测试与覆盖率：不适用，本次仅修改前端代码。
- 公共契约：仅增加模块注册组件及可选 `defaultTab` 属性，无 SPI 变更。
- 代码注释：已说明跨模块注册和默认页签用途。
- TraceHolder / MBean：不适用，本次不涉及后端链路与常驻任务。

## 关联

- 配合 `edge-master-ui` PR #4 的边缘网关设备接入详情复用。
