### PR TITLE
fix（设备）：禁止启用设备打开删除确认

### DIFF
--- a/docs/plans/device-list-figma-style-alignment.md
+++ b/docs/plans/device-list-figma-style-alignment.md
@@ -74,6 +74,18 @@
 
 ## 实施与验证结果
 
+### 设备详情删除禁用态修复
+
+- 目标：设备处于启用状态时，详情页删除按钮保持置灰，点击后不得打开删除确认弹层；设备禁用后仍保留原有确认删除流程。
+- 影响范围与 owning module：`device-manager-ui` 的 `views/device/list/components/IotDeviceDetailView.vue`，不修改列表页、接口、设备状态规则、权限或 `runtime-ui/`。
+- 实施入口：将删除按钮的禁用条件同步传给 Ant Design Vue `a-popconfirm`，并保留 `confirmDeleteDevice` 中的状态二次校验。
+- 风险：仅影响详情页删除确认弹层的打开条件；需回归启用态不可打开、禁用态可打开并正常确认。
+- 验证结果：
+  - `git diff --check`：通过。
+  - `pnpm -F jetlinks-web-core build -- --module-name device-manager-ui`：通过，共转换 `9449` 个模块；构建仅输出既有 CSS 注释、资源运行时解析和大 chunk 警告。
+  - `pnpm exec vue-tsc --noEmit -p modules/device-manager-ui/tsconfig.json --pretty false`：被既有的 `views/link/Certificate/type.d.ts:2` 语法错误阻断，本次修改文件未出现在错误输出中。
+  - 当前本地 `9100`、`9101`、`9102`、`5173` 端口均无可用页面，未执行浏览器点击回归；已核验当前 Ant Design Vue `a-popconfirm` 的 `disabled` 会在打开回调处直接返回。
+
 已完成：
 
 - `IotDeviceAssetListView.vue`：隐藏路由图标，保留标题与新增设备操作，不改变点击行为。

--- a/views/device/list/components/IotDeviceDetailView.vue
+++ b/views/device/list/components/IotDeviceDetailView.vue
@@ -188,6 +188,7 @@
         </a-popconfirm>
         <a-popconfirm
           :title="$t('IotDeviceList.confirm.deleteOne', { name: device.name })"
+          :disabled="deleteActionDisabled"
           :ok-button-props="{ loading: actionBusyId === device.id && actionKind === 'delete' }"
           @confirm="confirmDeleteDevice"
         >
@@ -195,7 +196,7 @@
             size="small"
             danger
             :loading="actionBusyId === device.id && actionKind === 'delete'"
-            :disabled="Boolean(actionBusyId && actionKind !== 'delete') || !isDeviceDisabled"
+            :disabled="deleteActionDisabled"
           >
             <template #icon><AIcon type="DeleteOutlined" /></template>
             {{ $t('IotDeviceDetail.detail.delete') }}
@@ -671,6 +672,8 @@ const businessGroupText = computed(() => limitedDisplayText(businessGroupItems.v
 const businessGroupFullText = computed(() => displayText(businessGroupItems.value.join($t('IotDeviceList.presentation.separator'))))
 const lastSeenText = computed(() => displayText(device.value?.lastSeen))
 const isDeviceDisabled = computed(() => device.value ? getIotDeviceConnectionStatus(device.value) === 'disabled' : false)
+// 启用状态或其他操作执行中时，删除入口和确认弹层必须同时禁用。
+const deleteActionDisabled = computed(() => Boolean(actionBusyId.value && actionKind.value !== 'delete') || !isDeviceDisabled.value)
 
 const productTemplate = computed(() => {
   if (!device.value?.productKey) return null


### PR DESCRIPTION
## 变更\n- 设备启用时同步禁用删除按钮与确认弹层\n- 保留确认处理中的状态二次校验\n\n## 验证\n- 模块定向构建通过\n- git diff --check 通过\n- 全量 vue-tsc 受模块既有类型声明语法错误阻断，本次文件未出现在错误输出