### PR TITLE
fix(设备管理): 修复标签时间与通知用户回显

### DIFF
--- a/api/scene-linkage.ts
+++ b/api/scene-linkage.ts
@@ -112,11 +112,21 @@ export const querySceneContextRecords = (id: string, contextId: string, data: Re
 export const querySceneNotifyChannels = () =>
   request.get('/notify/channel/all')
 
-export const querySceneNotifyUsers = (data: { pageIndex: number; pageSize: number }) =>
-  request.post('/user/detail/_query', {
-    ...data,
+export const querySceneNotifyUsers = (data: {
+  pageIndex?: number
+  pageSize?: number
+  paging?: boolean
+  userIds?: string[]
+}) => {
+  const { userIds, ...params } = data
+  return request.post('/user/detail/_query', {
+    ...params,
+    terms: userIds?.length
+      ? [{ column: 'id', termType: 'in', value: userIds }]
+      : undefined,
     sorts: [{ name: 'name', order: 'asc' }],
   })
+}
 
 export const querySceneNotifyChannelTemplates = (providerId: string) =>
   request.get(`/notify/channel/${encodeURIComponent(providerId)}/_query-with-templates`)

--- a/utils/notifyUser.ts
+++ b/utils/notifyUser.ts
@@ -1,0 +1,15 @@
+type NotifyUser = {
+  id: string
+}
+
+/**
+ * Keep existing option positions while refreshing user details so selected tags do not jump.
+ */
+export function mergeNotifyUsersById<T extends NotifyUser>(previous: T[], incoming: T[]): T[] {
+  const users = new Map(previous.map((user) => [user.id, user]))
+  incoming.forEach((user) => {
+    const existing = users.get(user.id)
+    users.set(user.id, existing ? { ...existing, ...user } : user)
+  })
+  return [...users.values()]
+}

--- a/views/device/alarm/api.ts
+++ b/views/device/alarm/api.ts
@@ -76,11 +76,21 @@ export const deviceAlarmApi = {
     request.remove(`/message/preprocessor/device/${productId}/${deviceId}/property/${propertyId}`, data),
   queryNotifyChannels: () =>
     request.get('/notify/channel/all'),
-  queryNotifyUsers: (data: { pageIndex: number; pageSize: number }) =>
-    request.post('/user/detail/_query', {
-      ...data,
+  queryNotifyUsers: (data: {
+    pageIndex?: number
+    pageSize?: number
+    paging?: boolean
+    userIds?: string[]
+  }) => {
+    const { userIds, ...params } = data
+    return request.post('/user/detail/_query', {
+      ...params,
+      terms: userIds?.length
+        ? [{ column: 'id', termType: 'in', value: userIds }]
+        : undefined,
       sorts: [{ name: 'name', order: 'asc' }],
-    }),
+    })
+  },
   queryInstalledDeviceLibrary: (capabilityId: string) =>
     request.post(`/marketplace/capabilities/device-template/${encodeURIComponent(capabilityId)}/installed`, []),
   queryDeviceLibraryResources: () =>
@@ -249,12 +259,12 @@ export function toNotifyMethods(providers: unknown[]): DeviceAlarmNotifyMethod[]
 }
 
 export async function queryDeviceAlarmNotifyUsers(
-  params: { pageIndex?: number; pageSize?: number } = {},
+  params: { pageIndex?: number; pageSize?: number; paging?: boolean; userIds?: string[] } = {},
 ): Promise<{ data: DeviceAlarmNotifyUser[]; total: number }> {
   const pageIndex = Math.max(0, Number(params.pageIndex ?? 0))
   const pageSize = Math.max(1, Number(params.pageSize ?? 20))
   const page = normalizeAlarmTargetPage(
-    await deviceAlarmApi.queryNotifyUsers({ pageIndex, pageSize }),
+    await deviceAlarmApi.queryNotifyUsers({ ...params, pageIndex, pageSize }),
     pageIndex,
     pageSize,
   )

--- a/views/device/alarm/hooks/useDeviceAlarmPage.ts
+++ b/views/device/alarm/hooks/useDeviceAlarmPage.ts
@@ -40,6 +40,7 @@ import {
   validateNotificationMessage,
 } from '../utils'
 import type { IotAlarmTargetSelectOption, IotAlarmTargetSelectQuery } from '../components/IotAlarmTargetSelect.vue'
+import { mergeNotifyUsersById } from '../../../../utils/notifyUser'
 
 export function useDeviceAlarmPage(t: (key: string, params?: Record<string, unknown>) => string) {
   const loading = ref(false)
@@ -301,12 +302,21 @@ export function useDeviceAlarmPage(t: (key: string, params?: Record<string, unkn
   async function loadNotifyResources() {
     notifyLoading.value = true
     try {
-      const [channels, users] = await Promise.all([
+      const selectedUserIds = [...new Set(form.value.notification.userIds.map(String).filter(Boolean))]
+      // Saved recipients may be outside the first dropdown page, so resolve them separately.
+      const [channels, users, selectedUsers] = await Promise.all([
         queryDeviceAlarmNotifyProviders().catch(() => []),
         queryDeviceAlarmNotifyUsers({ pageIndex: 0 }).catch(() => ({ data: [], total: 0 })),
+        selectedUserIds.length
+          ? queryDeviceAlarmNotifyUsers({ paging: false, userIds: selectedUserIds }).catch(() => ({ data: [], total: 0 }))
+          : Promise.resolve({ data: [], total: 0 }),
       ])
       notifyMethods.value = toNotifyMethods(channels)
-      notifyUsers.value = users.data
+      const retainedUsers = notifyUsers.value.filter((user) => selectedUserIds.includes(user.id))
+      notifyUsers.value = mergeNotifyUsersById(
+        retainedUsers,
+        mergeNotifyUsersById(selectedUsers.data, users.data),
+      )
       notifyUserPageIndex.value = 0
       notifyUserTotal.value = users.total
     } finally {
@@ -319,9 +329,7 @@ export function useDeviceAlarmPage(t: (key: string, params?: Record<string, unkn
     notifyLoading.value = true
     try {
       const page = await queryDeviceAlarmNotifyUsers({ pageIndex: notifyUserPageIndex.value + 1 })
-      const userMap = new Map(notifyUsers.value.map((user) => [user.id, user]))
-      page.data.forEach((user) => userMap.set(user.id, user))
-      notifyUsers.value = [...userMap.values()]
+      notifyUsers.value = mergeNotifyUsersById(notifyUsers.value, page.data)
       notifyUserPageIndex.value += 1
       notifyUserTotal.value = page.total
     } finally {

--- a/views/device/list/components/IotDeviceTagEditorModal.vue
+++ b/views/device/list/components/IotDeviceTagEditorModal.vue
@@ -25,11 +25,20 @@
         <div v-else-if="column.dataIndex === 'name'" class="device-tag-editor__name">
           <j-ellipsis>{{ getTagLabel(record) }}</j-ellipsis>
         </div>
-        <MetadataValueItem
-          v-else
-          v-model="record.value"
-          :item="record"
-        />
+        <template v-else>
+          <j-value-item
+            v-if="getTagType(record) === 'date'"
+            v-model:modelValue="record.value"
+            item-type="date"
+            value-format="YYYY-MM-DD HH:mm:ss"
+            style="width: 100%"
+          />
+          <MetadataValueItem
+            v-else
+            v-model="record.value"
+            :item="record"
+          />
+        </template>
       </template>
     </a-table>
   </a-modal>

--- a/views/scene-linkage/editor/index.vue
+++ b/views/scene-linkage/editor/index.vue
@@ -294,6 +294,7 @@ import { onlyMessage } from '@jetlinks-web-core/utils/comm'
 import { createSceneLinkage, getProduct, getSceneDetail, queryDevices, queryProducts, querySceneNotifyChannelTemplates, querySceneNotifyChannels, querySceneNotifyUsers, querySceneSupportedActions, querySceneSupportedTriggers, updateSceneLinkage, type SceneNotifyMethod, type SceneNotifyUser, type SceneProviderInfo } from '../../../api/scene-linkage'
 import { queryDeviceBoundGroups_api, queryDeviceGroupDetailList_api } from '../../../api/deviceGroup'
 import { queryDeviceSpaceAreaBindings_api, queryProjectSpaceAreaSettings_api } from '../../../api/spaceArea'
+import { mergeNotifyUsersById } from '../../../utils/notifyUser'
 import IotAlarmTargetSelect, { type IotAlarmTargetSelectOption, type IotAlarmTargetSelectQuery } from '../../device/alarm/components/IotAlarmTargetSelect.vue'
 import { applyMultiTriggerForm, buildRequest, defaultForm, normalizeResult, toForm, type SceneConditionForm, type SceneLinkageForm, type SceneMultiTriggerForm, type SceneTriggerKind } from '../utils'
 import ActionPickerModal from './components/ActionPickerModal.vue'
@@ -393,7 +394,40 @@ async function changeNotifyMethod(index: number, method: SceneNotifyMethod) { aw
 async function refreshNotifyTemplate(index: number, method: SceneNotifyMethod, changed = false) { const response: any = await querySceneNotifyChannelTemplates(method.providerId); const detail = response?.result ?? response; const item = detail?.channels?.find((channel: any) => channel.channel?.id === method.id); form.actions[index] = { ...form.actions[index], config: { ...form.actions[index].config, ...(changed ? { notifyChannelIds: [method.id] } : {}) }, options: { ...form.actions[index].options, channelName: method.name, templateContent: getTemplateContent(item?.template) } } }
 function getTemplateContent(template: any) { const content = template?.template || {}; const getByPath = (source: any, path: string[]) => path.reduce((target, key) => target && typeof target === 'object' && !Array.isArray(target) ? target[key] : undefined, source); const asText = (value: unknown) => typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''; const firstText = (...values: unknown[]) => values.map(asText).find(Boolean) || ''; return firstText(getByPath(content, ['message']), getByPath(content, ['ttsmessage']), getByPath(content, ['body']), getByPath(content, ['text', 'content']), getByPath(content, ['markdown', 'text']), getByPath(content, ['link', 'text']), getByPath(content, ['text'])) }
 async function loadNotifyMethods(force = false) { if ((!force && notifyMethods.value.length) || notifyMethodsLoading.value) return; notifyMethodsLoading.value = true; try { const providers: any[] = normalizeResult(await querySceneNotifyChannels()).data; notifyMethods.value = providers.filter(provider => provider.provider === 'scene').flatMap(provider => (provider.channels || []).map((channel: any) => ({ id: channel.id, providerId: provider.id || provider.provider, name: channel.name || channel.channelProvider, channelProvider: channel.channelProvider }))).filter(method => method.id && method.providerId && method.channelProvider?.startsWith('notifier-')); } finally { notifyMethodsLoading.value = false } }
-async function loadNotifyUsers(reset = true) { if (notifyUsersLoading.value || (!reset && notifyUsers.value.length >= notifyUsersTotal.value)) return; const pageIndex = reset ? 0 : notifyUsersPageIndex.value + 1; notifyUsersLoading.value = true; try { const page = normalizeResult(await querySceneNotifyUsers({ pageIndex, pageSize: 20 })); const users = page.data.map((user: any) => ({ id: user.id, name: user.name, username: user.username, email: user.email, telephone: user.telephone })); const userMap = new Map((reset ? [] : notifyUsers.value).map(user => [user.id, user])); users.forEach(user => userMap.set(user.id, user)); notifyUsers.value = [...userMap.values()]; notifyUsersPageIndex.value = pageIndex; notifyUsersTotal.value = Number(page.total ?? pageIndex * 20 + users.length); } finally { notifyUsersLoading.value = false } }
+const selectedNotifyUserIds = () => [...new Set(form.actions
+  .filter(action => action.type === 'sceneNotify')
+  .flatMap(action => action.config?.userIds || [])
+  .map(String)
+  .filter(Boolean))]
+const toSceneNotifyUsers = (users: any[]): SceneNotifyUser[] => users
+  .map(user => ({ id: String(user.id || ''), name: user.name, username: user.username, email: user.email, telephone: user.telephone }))
+  .filter((user): user is SceneNotifyUser => Boolean(user.id))
+async function loadNotifyUsers(reset = true) {
+  if (notifyUsersLoading.value || (!reset && notifyUsers.value.length >= notifyUsersTotal.value)) return
+  const pageIndex = reset ? 0 : notifyUsersPageIndex.value + 1
+  const userIds = selectedNotifyUserIds()
+  notifyUsersLoading.value = true
+  try {
+    // Saved recipients may be outside the first dropdown page, so resolve them separately.
+    const [pageResponse, selectedResponse] = await Promise.all([
+      querySceneNotifyUsers({ pageIndex, pageSize: 20 }),
+      reset && userIds.length
+        ? querySceneNotifyUsers({ paging: false, userIds }).catch(() => undefined)
+        : Promise.resolve(undefined),
+    ])
+    const page = normalizeResult(pageResponse)
+    const selectedUsers = selectedResponse ? toSceneNotifyUsers(normalizeResult(selectedResponse).data) : []
+    const retainedUsers = reset ? notifyUsers.value.filter(user => userIds.includes(user.id)) : notifyUsers.value
+    notifyUsers.value = mergeNotifyUsersById(
+      retainedUsers,
+      mergeNotifyUsersById(selectedUsers, toSceneNotifyUsers(page.data)),
+    )
+    notifyUsersPageIndex.value = pageIndex
+    notifyUsersTotal.value = Number(page.total ?? pageIndex * 20 + page.data.length)
+  } finally {
+    notifyUsersLoading.value = false
+  }
+}
 const isEmptyValue = (value: unknown) => value === undefined || value === null || value === ''
 async function getMissingFunctionInputs(action: any) {
   const message = action.config?.message || {}
@@ -411,7 +445,7 @@ watch(() => form.repeatMode, (_value, previous) => { if (!loadingScene.value && 
 watch(() => form.name, value => { if (value.trim() && hasError('name')) { validation.field = ''; validation.message = '' } })
 watch(() => [form.propertyId, form.termValue], ([propertyId, termValue]) => { if (propertyId && termValue !== undefined && termValue !== null && termValue !== '' && hasError('property')) { validation.field = ''; validation.message = '' } })
 // Keep persisted weekly or monthly selections while the edit form is being populated.
-async function init() { await loadSceneProviders(); const id = String(route.params.id || ''); if (!id) { form.triggerKind = '' as SceneTriggerKind; return }; const data: any = await getSceneDetail(id); Object.assign(form, toForm(data.result || data)); advancedExpanded.value = form.debounceEnabled; if (form.productId) { const response: any = await getProduct(form.productId); const product = response.result || response; form.productName ||= product.name || form.productId; selectedProductOption.value = { label: product.name || form.productId, value: form.productId, data: product }; await loadMetadata(true) }; await nextTick(); loadingScene.value = false; if (form.actions.some(action => action.type === 'sceneNotify')) { await loadNotifyMethods(); await Promise.all(form.actions.map((action, index) => { const method = action.type === 'sceneNotify' ? notifyMethods.value.find(item => item.id === action.config?.notifyChannelIds?.[0]) : undefined; return method ? refreshNotifyTemplate(index, method) : undefined })) } }
+async function init() { await loadSceneProviders(); const id = String(route.params.id || ''); if (!id) { form.triggerKind = '' as SceneTriggerKind; return }; const data: any = await getSceneDetail(id); Object.assign(form, toForm(data.result || data)); advancedExpanded.value = form.debounceEnabled; if (form.productId) { const response: any = await getProduct(form.productId); const product = response.result || response; form.productName ||= product.name || form.productId; selectedProductOption.value = { label: product.name || form.productId, value: form.productId, data: product }; await loadMetadata(true) }; await nextTick(); loadingScene.value = false; if (form.actions.some(action => action.type === 'sceneNotify')) { await Promise.all([loadNotifyMethods(), loadNotifyUsers()]); await Promise.all(form.actions.map((action, index) => { const method = action.type === 'sceneNotify' ? notifyMethods.value.find(item => item.id === action.config?.notifyChannelIds?.[0]) : undefined; return method ? refreshNotifyTemplate(index, method) : undefined })) } }
 init()
 </script>
 <style src="./SceneLinkageEditor.css"></style>


### PR DESCRIPTION
## 目的

- 修复场景联动和设备告警编辑时，已保存通知用户首次仅显示 ID 的问题
- 消除下拉分页加载后已选用户标签重新排序、跳动的问题
- 修复设备详情标签编辑中日期时间值仅显示日期、无法配置时分秒的问题

## 核心变动

- 场景联动：按已保存的 `userIds` 单独回查用户详情，并与分页数据稳定合并
- 设备告警：打开编辑弹窗时同步回查已选用户；滚动加载仅追加或更新既有选项
- 设备详情标签：日期类型改用带 `YYYY-MM-DD HH:mm:ss` 值格式的日期时间控件
- 设备管理模块：新增按 ID 稳定合并通知用户选项的工具函数

## 设计与测试目标

- 设计稿：不适用；局部控件回显与时间编辑修复，未改变页面结构或接口契约
- 用户确认：已确认
- 测试目标：覆盖已选用户不在第 1 页、滚动加载包含已选用户、重复用户去重且标签顺序稳定，以及日期类型标签可编辑时分秒
- 注释 / 公共契约：不适用；已在用户回查和稳定合并关键逻辑处补充必要说明
- 数据权限：不适用；未修改权限、资产或后端查询语义
- 数据库兼容与性能：不适用；未新增数据库访问或 SQL
- 链路追踪：不适用；纯前端状态与控件修复
- MBean 运维可观测性：不适用；纯前端状态与控件修复

## 测试结果

- 命令：`pnpm exec vue-tsc --noEmit`
- 新增/更新测试：未新增自动化用例；已通过 TypeScript 全量类型检查并由用户完成页面交互确认
- 单元测试：不适用：当前改动为前端控件回显、分页状态和日期时间编辑修复，项目未提供对应组件单测入口
- 集成测试：不适用：未涉及数据库、消息、事件、协议、跨模块服务边界或启动装配
- 压力测试：不适用：未新增高频请求、批处理或服务端查询逻辑
- 覆盖率：未提供前端 changed-files 覆盖率工具；替代证据为 TypeScript 全量类型检查通过与用户交互确认

## 文档同步情况

- 已同步：无
- 未同步：无；模块职责、路由和接口文档均未变化
- 说明：未修改 README；测试证据保留在 PR 描述和 CI 中

## 风险与说明

- 影响范围：SaaS 物联的场景联动编辑、设备告警编辑通知用户选择器，以及设备详情标签编辑弹窗
- 注释 / 公共契约：不涉及公共组件或后端契约；稳定合并逻辑已注释
- 链路追踪 / 可观测性：不涉及
- MBean / 运维可观测性：不涉及
- 未覆盖场景：未连接实际后端重新执行浏览器自动化；用户已人工确认修复效果
- 已知限制：已保存用户被删除或当前账号无权读取时，后端无法返回其姓名，控件将保留原始 ID