### PR TITLE
fix: 修复设备属性值截断与单位展示

### DIFF
--- a/views/device/list/components/device-detail/IotDevicePropertyValuePreview.vue
+++ b/views/device/list/components/device-detail/IotDevicePropertyValuePreview.vue
@@ -1,7 +1,7 @@
 <template>
-  <span v-if="raw" class="property-value-preview property-value-preview--text">
+  <j-ellipsis v-if="raw" class="property-value-preview property-value-preview--text">
     {{ rawText }}
-  </span>
+  </j-ellipsis>
   <a-tooltip v-else-if="structuredValue" :title="$t('IotDeviceDetail.propertyDetail.viewDetail')">
     <button
       type="button"
@@ -20,9 +20,9 @@
     :height="thumbnailSize"
     class="property-value-preview property-value-preview--image"
   />
-  <span v-else class="property-value-preview property-value-preview--text">
+  <j-ellipsis v-else class="property-value-preview property-value-preview--text">
     {{ displayValue }}
-  </span>
+  </j-ellipsis>
 
   <a-modal
     v-model:open="detailOpen"

--- a/views/device/list/components/device-detail/iotDevicePropertyDisplay.ts
+++ b/views/device/list/components/device-detail/iotDevicePropertyDisplay.ts
@@ -9,7 +9,10 @@ export function splitPropertyValueAndUnit(value: unknown, unit?: string): Displa
   const text = String(value ?? '').trim()
   if (!text || text === '--') return { value: '--', unit: '' }
 
-  // 设备值可能已来自 formatValue，部分协议会把单位拼进值里；先拆开再展示，避免重复单位。
+  const normalizedUnit = String(unit ?? '').trim()
+  if (!normalizedUnit) return { value: text, unit: '' }
+
+  // 设备值可能已来自 formatValue，部分协议会把已配置单位拼进值里；先拆开再展示，避免重复单位。
   const inlineUnit = text.match(/^([+-]?\d+(?:\.\d+)?)(?:\s*)([^\d\s].*)$/u)
   if (inlineUnit) {
     return {
@@ -18,7 +21,7 @@ export function splitPropertyValueAndUnit(value: unknown, unit?: string): Displa
     }
   }
 
-  return { value: text, unit: String(unit ?? '').trim() }
+  return { value: text, unit: normalizedUnit }
 }
 
 export function getPropertyDisplayValue(item: RealtimePropertyRow) {


### PR DESCRIPTION
## 目的

- 修复设备详情中长文本属性值无法截断，以及未配置单位时值被拆分显示的问题
- 保持对象、图片等其他属性预览逻辑不变

## 核心变动

- device-manager-ui：文本属性值预览复用 j-ellipsis 进行单行截断。
- device-manager-ui：仅在配置单位后拆分内联单位；未配置单位时保留完整原始值。

## 设计与测试目标

- 设计稿：不适用；窄范围展示修复，未调整页面结构或交互路径
- 用户确认：已要求创建提交并发起 PR
- 测试目标：验证文本属性的截断渲染和缺省单位时的原始值展示
- 注释 / 公共契约：不适用；未新增公共契约或复杂业务分支
- 数据权限：不适用；未涉及查询或操作权限
- 数据库兼容与性能：不适用；未涉及后端或数据库
- 链路追踪：不适用；未涉及后端调用链路
- MBean 运维可观测性：不适用；未涉及常驻任务、缓存或后台执行器

## 测试结果

- 命令：`pnpm -F jetlinks-web-core build -- --module-name device-manager-ui`
- 构建：9507 modules transformed，0 errors，exit 0
- 单元测试：不适用；当前模块没有覆盖该属性展示组件的测试脚本，未将无关 test:agent-tools 作为验证依据
- 集成测试：不适用；未涉及后端、数据库、消息、协议、跨模块服务边界或启动装配
- 压力测试：不适用；纯前端展示逻辑变更
- 覆盖率：未生成；当前定向构建流程不输出该组件的覆盖率，已使用生产构建与 git diff --check 验证

## 文档同步情况

- 已同步：无
- 未同步：无；模块说明和既有文档未记录此内部展示规则，无需修改长期文档
- 说明：未新建单次任务记录；测试证据由 PR 承载

## 风险与说明

- 影响范围：设备详情的文本属性值预览与单位显示
- 注释 / 公共契约：不涉及
- 链路追踪 / 可观测性：不涉及
- MBean 运维可观测性：不涉及
- 未覆盖场景：未在真实浏览器会话中手工验证超长值、配置单位和未配置单位三种展示组合
- 已知限制：构建仍有资源运行时解析、CSS 注释和大 chunk 警告；本次触达文件未引用相应资源或 CSS 规则