### PR TITLE
fix(设备管理): 修复设备列表路由与事件标签溢出

### DIFF
--- a/agentCapabilities/deviceAnalysis/constants.ts
+++ b/agentCapabilities/deviceAnalysis/constants.ts
@@ -11,6 +11,6 @@ export const IOT_DEVICE_OPEN_DETAIL_TABS = ['overview', 'access', 'data', 'alarm
 
 export const IOT_DEVICE_MENU_ANCHORS = {
   overview: ['iot-user/device/overview', '/iot-user/device/overview'],
-  list: ['iot-user/device', '/iot-user/device'],
+  list: ['iot-user/device/list', '/iot-user/device/list'],
   health: ['iot-user/device/health', '/iot-user/device/health'],
 } as const

--- a/views/device/list/components/device-detail/IotDeviceEventHistoryPane.css
+++ b/views/device/list/components/device-detail/IotDeviceEventHistoryPane.css
@@ -22,6 +22,14 @@
 
 .event-history__tabs :deep(.ant-tabs-nav) {
   margin: 0;
+  width: 100%;
+  min-width: 0;
+}
+
+.event-history__tabs :deep(.ant-tabs-nav-wrap),
+.event-history__tabs :deep(.ant-tabs-nav-list) {
+  width: 100%;
+  min-width: 0;
 }
 
 .event-history__tabs :deep(.ant-tabs-ink-bar) {
@@ -29,10 +37,20 @@
 }
 
 .event-history__tabs :deep(.ant-tabs-tab) {
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
+  overflow: hidden;
   margin: 0 0 var(--space-1) !important;
   border-radius: var(--jet-theme-radius);
   padding: var(--space-2) var(--space-3) !important;
+}
+
+.event-history__tabs :deep(.ant-tabs-tab-btn) {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .event-history__tabs :deep(.ant-tabs-tab-active) {
@@ -44,9 +62,12 @@
 }
 
 .event-history__tab {
-  display: inline-flex;
+  display: flex;
+  flex: 1 1 0;
   align-items: baseline;
   gap: var(--space-2);
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
   overflow: hidden;
   color: var(--jet-theme-text-secondary);
@@ -54,17 +75,18 @@
 
 .event-history__tab strong,
 .event-history__tab small {
-  overflow: hidden;
-  text-overflow: ellipsis;
+  min-width: 0;
   white-space: nowrap;
 }
 
 .event-history__tab strong {
+  flex: 0 1 auto;
   color: inherit;
   font-weight: 600;
 }
 
 .event-history__tab small {
+  flex: 1 1 0;
   color: var(--jet-theme-text-disabled);
   font-size: var(--fs-14);
 }

--- a/views/device/list/components/device-detail/IotDeviceEventHistoryPane.vue
+++ b/views/device/list/components/device-detail/IotDeviceEventHistoryPane.vue
@@ -8,7 +8,7 @@
     >
       <a-tab-pane v-for="event in events" :key="event.id">
         <template #tab>
-          <span class="event-history__tab" :title="event.name || event.id">
+          <span class="event-history__tab" :title="event.name + event.id">
             <strong>{{ event.name || event.id }}</strong>
             <small v-if="event.id">{{ event.id }}</small>
           </span>

--- a/views/device/list/hooks/useIotDeviceRouting.ts
+++ b/views/device/list/hooks/useIotDeviceRouting.ts
@@ -30,7 +30,7 @@ export function resolveIotProjectId(route: IotRouteLike, fallback = 'doraemon') 
 }
 
 export function buildIotDeviceListPath(projectId: string, route?: IotRouteLike) {
-  if (!isProjectIotRoute(route)) return '/iot-user/device'
+  if (!isProjectIotRoute(route)) return '/iot-user/device/list'
 
   return `/project/${encodePathSegment(projectId)}/iot-user/list`
 }


### PR DESCRIPTION
## 目的

- 修复设备分析入口无法匹配物联设备列表菜单的问题。
- 修复详情页回退到旧设备列表地址，以及事件名称过长撑宽左侧标签列的问题。

## 核心变动

- 设备分析：将列表菜单锚点统一为 `/iot-user/device/list`。
- 设备详情：非项目路径回退到 `/iot-user/device/list`。
- 事件历史：限制 Ant Tabs 导航列与标签内容的可收缩宽度，防止长事件文本突破左侧容器。

## 设计与测试目标

- 设计稿：不适用；本次为既有详情页的局部路由与布局修复。
- 用户确认：已确认，用户要求创建分支、提交并向 `2.12-uat-next` 发起 PR。
- 测试目标：验证菜单锚点、详情页回退路径及长事件文本不再撑宽左栏。
- 注释 / 公共契约：不适用；未修改公共契约、SPI 或复杂业务分支。
- 数据权限：不适用；未涉及 CRUD 或资产权限逻辑。
- 数据库兼容与性能：不适用；未涉及数据库或 SQL。
- 链路追踪：不适用；未涉及后端链路。
- MBean 运维可观测性：不适用；未涉及常驻后端能力。

## 测试结果

- 命令：`pnpm test:agent-tools`
- 新增/更新测试：无；本次未修改测试目标代码。
- 单元测试：42 passed, 0 failed, 0 skipped。
- 页面实测：事件标签左栏容器 218px、导航列 194px、标签按钮 170px，三者 scrollWidth 与可视宽度一致。
- 定向构建：`pnpm -F jetlinks-web-core build -- --module-name device-manager-ui` 已生成模块产物；构建过程中存在既有 `Unknown output options: input` 及 3 条资源延迟解析警告。
- 集成测试：不适用；未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配。
- 压力测试：不适用；未涉及性能敏感链路。
- 覆盖率：模块现有测试脚本未输出覆盖率数据；以 42 条自动化断言和页面尺寸实测作为替代验证。

## 文档同步情况

- 已同步：无；本次不改变模块长期职责、接口或使用说明。
- 未同步：无。
- 说明：测试证据保留在本 PR，未修改 README。

## 风险与说明

- 影响范围：设备分析菜单可见性、设备详情页回退地址、详情事件历史左侧标签布局。
- 注释 / 公共契约：不涉及。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未覆盖不同浏览器及极端多语言事件名的端到端自动化回归。
- 已知限制：模块定向构建保留现有构建配置与资源解析警告，需由 CI 继续确认。