### PR TITLE
fix(设备管理): 修复总览在线率统计

### DIFF
--- a/api/deviceTrend.ts
+++ b/api/deviceTrend.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs'
 
+import { IOT_DEVICE_DASHBOARD_ACCESS_PROVIDERS } from '../dataCapabilities/deviceScope'
+
 const MIN_TIMESTAMP = 946684800000
 
 export type DeviceGroupTrendMetricKey = 'onlineRate' | 'uplink'
@@ -20,6 +22,7 @@ export interface DeviceGroupTrendMetric {
 export interface DeviceTrendDashboardScope {
   groupId?: string
   spaceId?: string | string[]
+  accessProvider?: readonly string[]
 }
 
 export interface DeviceTrendDashboardRange {
@@ -112,7 +115,11 @@ export function buildDeviceTrendDashboardQueries(
   range: DeviceTrendDashboardRange,
   metrics: readonly DeviceGroupTrendMetricKey[],
 ): DeviceTrendDashboardQuery[] {
-  const params = { ...scope, ...range }
+  const params = {
+    ...scope,
+    accessProvider: scope.accessProvider ?? IOT_DEVICE_DASHBOARD_ACCESS_PROVIDERS,
+    ...range,
+  }
   return metrics.map(metric => metric === 'onlineRate'
     ? {
       dashboard: 'device',

--- a/components/useIotDeviceWorkbench.ts
+++ b/components/useIotDeviceWorkbench.ts
@@ -67,6 +67,7 @@ export interface DeviceStatCard {
   tone: DashboardTone | 'default'
   target: Partial<IotDeviceFilters>
   sparkline?: number[]
+  sparklineDomain?: readonly [number, number]
   breakdown?: Array<{
     label: string
     value: number
@@ -351,6 +352,7 @@ const deviceStatCards = computed<DeviceStatCard[]>(() => {
       tone: 'muted',
       target: { connectionStatus: 'online', businessStatus: 'all', risk: 'all', anomalyKind: 'all' },
       sparkline: overviewMetrics.onlineRateTrend.value.map((item) => item.value),
+      sparklineDomain: [0, 100],
       trend: { direction: 'flat', value: $t('IotWorkbench.trend.flat'), label: $t('IotWorkbench.stat.realtime'), tone: 'muted' },
     },
     {

--- a/components/workbench/IotDeviceStatPanel.vue
+++ b/components/workbench/IotDeviceStatPanel.vue
@@ -88,20 +88,21 @@ const sparklinePoints: Record<string, string> = {
   alarm: '2,34 10,30 18,32 26,18 34,24 42,10 50,28 58,6 66,18 74,8 82,26 88,14',
 }
 
-function buildSparklinePoints(values: number[]) {
+function buildSparklinePoints(values: number[], domain?: readonly [number, number]) {
   if (values.length < 2) return ''
-  const max = Math.max(...values)
-  const min = Math.min(...values)
+  const [min, max] = domain ?? [Math.min(...values), Math.max(...values)]
   const range = Math.max(max - min, 1)
   return values.map((value, index) => {
     const x = 2 + (index / (values.length - 1)) * 86
-    const y = 36 - ((value - min) / range) * 30
+    const normalizedValue = Math.min(Math.max(value, min), max)
+    const y = 36 - ((normalizedValue - min) / range) * 30
     return `${Math.round(x)},${Math.round(y)}`
   }).join(' ')
 }
 
 function statSparklinePoints(item: DeviceStatCard) {
-  if (item.sparkline) return buildSparklinePoints(item.sparkline)
+  // Percent trends retain their 0–100 domain so a low rate is not visually magnified.
+  if (item.sparkline) return buildSparklinePoints(item.sparkline, item.sparklineDomain)
   return sparklinePoints[item.key] ?? ''
 }
 


### PR DESCRIPTION
## 目的

- 修复物联设备总览的聚合在线率口径。
- 让在线率卡片的小趋势图按百分比真实尺度展示。

## 核心变动

- `api/deviceTrend.ts`：设备在线率和上行消息聚合请求默认携带正常设备接入方式的 `accessProvider` 白名单。
- `useIotDeviceWorkbench.ts`：为在线率统计卡声明固定的 0–100% 趋势值域。
- `IotDeviceStatPanel.vue`：支持指定趋势值域，避免低在线率数据被自适应缩放为满幅折线。

## 设计与测试目标

- 设计稿：不适用；仅修复既有总览统计口径和展示比例尺。
- 用户确认：已确认。
- 测试目标：覆盖聚合请求白名单、在线率趋势固定百分比值域与模块生产构建。
- 注释 / 公共契约：适用；百分比趋势保留固定值域的原因已在展示转换处说明。
- 数据权限：不适用；未改动权限或资产范围。
- 数据库兼容与性能：不适用；未改动数据库查询。
- 链路追踪：不适用；纯前端改动。
- MBean 运维可观测性：不适用；纯前端改动。

## 测试结果

- 命令：`node --max_old_space_size=8192 --max-semi-space-size=64 -e "process.argv.push('--module-name','device-manager-ui'); import('vite').then(({ build }) => build())"`
- 新增/更新测试：无模块内新增测试文件；根工作区 `tests/unit/deviceTrendScopeContract.spec.ts` 已在本地通过 1 个契约测试脚本验证两个聚合请求均携带 `accessProvider` 白名单及显式 scope 参数，待子模块基线对齐后再单独提交。
- 单元测试：1 个根工作区本地契约测试脚本通过，0 failed，0 skipped。
- 集成测试：不适用；未涉及后端、数据库、消息、协议或外部服务。
- 压力测试：不适用；未改动服务端请求负载或存储查询。
- 覆盖率：项目未配置本次前端组件的覆盖率统计；以契约断言和生产构建作为替代验证。

## 文档同步情况

- 已同步：无；未改变长期模块契约或用户操作说明。
- 未同步：无。
- 说明：测试证据保留在 PR 描述，未新增临时任务文档。

## 风险与说明

- 影响范围：`/iot-user/device/overview` 的在线率和上行趋势聚合请求、在线率统计卡小趋势图。
- 注释 / 公共契约：已在固定百分比值域的展示转换处补充原因注释。
- 链路追踪 / 可观测性：不涉及。
- MBean / 运维可观测性：不涉及。
- 未覆盖场景：未在真实浏览器连接目标 dashboard 服务进行视觉回归。
- 已知限制：历史聚合数据不纳入本次兼容范围；根工作区子模块基线分叉，契约测试文件未纳入本 PR。